### PR TITLE
add the rest of the source yaml files

### DIFF
--- a/input/sources/tev-000001.yaml
+++ b/input/sources/tev-000001.yaml
@@ -1,0 +1,11 @@
+source_id: 1
+
+tevcat_id: 227
+tevcat2_id: rC5JCj
+tevcat_name: TeV J0006+729
+
+tgevcat_id: 1
+tgevcat_name: TeV J0006+7259
+
+papers:
+- null

--- a/input/sources/tev-000002.yaml
+++ b/input/sources/tev-000002.yaml
@@ -1,0 +1,11 @@
+source_id: 2
+
+tevcat_id: 213
+tevcat2_id: 70hRXZ
+tevcat_name: TeV J0013-188
+
+tgevcat_id: 2
+tgevcat_name: TeV J0013-1853
+
+papers:
+- null

--- a/input/sources/tev-000003.yaml
+++ b/input/sources/tev-000003.yaml
@@ -1,0 +1,11 @@
+source_id: 3
+
+tevcat_id: 209
+tevcat2_id: xCyAjF
+tevcat_name: TeV J0025+641
+
+tgevcat_id: 3
+tgevcat_name: TeV J0025+6410
+
+papers:
+- null

--- a/input/sources/tev-000004.yaml
+++ b/input/sources/tev-000004.yaml
@@ -1,0 +1,11 @@
+source_id: 4
+
+tevcat_id: 239
+tevcat2_id: PKJZqs
+tevcat_name: TeV J0033-193
+
+tgevcat_id: 4
+tgevcat_name: TeV J0033-1921
+
+papers:
+- null

--- a/input/sources/tev-000005.yaml
+++ b/input/sources/tev-000005.yaml
@@ -1,0 +1,11 @@
+source_id: 5
+
+tevcat_id: 229
+tevcat2_id: eNYfrm
+tevcat_name: 	TeV J0035+598
+
+tgevcat_id: 5
+tgevcat_name: TeV J0035+5947
+
+papers:
+- null

--- a/input/sources/tev-000006.yaml
+++ b/input/sources/tev-000006.yaml
@@ -1,0 +1,11 @@
+source_id: 6
+
+tevcat_id: 195
+tevcat2_id: sK2rQU
+tevcat_name: TeV J0047-253
+
+tgevcat_id: 6
+tgevcat_name: TeV J0047-2517
+
+papers:
+- null

--- a/input/sources/tev-000007.yaml
+++ b/input/sources/tev-000007.yaml
@@ -1,0 +1,11 @@
+source_id: 7
+
+tevcat_id: 244
+tevcat2_id: 7WhQrw
+tevcat_name: TeV J0136+391
+
+tgevcat_id: 7
+tgevcat_name: TeV J0136+3905
+
+papers:
+- null

--- a/input/sources/tev-000008.yaml
+++ b/input/sources/tev-000008.yaml
@@ -1,0 +1,11 @@
+source_id: 8
+
+tevcat_id: 156
+tevcat2_id: tKGVcC
+tevcat_name: TeV J0152+017
+
+tgevcat_id: 8
+tgevcat_name: TeV J0152+0146
+
+papers:
+- null

--- a/input/sources/tev-000009.yaml
+++ b/input/sources/tev-000009.yaml
@@ -1,0 +1,11 @@
+source_id: 9
+
+tevcat_id: 252
+tevcat2_id: 2I2TuY
+tevcat_name: TeV J0209+648
+
+tgevcat_id: 9
+tgevcat_name: TeV J0205+6451
+
+papers:
+- null

--- a/input/sources/tev-000010.yaml
+++ b/input/sources/tev-000010.yaml
@@ -1,0 +1,11 @@
+source_id: 10
+
+tevcat_id: 254
+tevcat2_id: hJnA37
+tevcat_name: TeV J0218+359
+
+tgevcat_id: 10
+tgevcat_name: TeV J0221+3556
+
+papers:
+- null

--- a/input/sources/tev-000011.yaml
+++ b/input/sources/tev-000011.yaml
@@ -1,0 +1,11 @@
+source_id: 11
+
+tevcat_id: 119
+tevcat2_id: J01xzR
+tevcat_name: TeV J0222+430
+
+tgevcat_id: 11
+tgevcat_name: TeV J0222+4302
+
+papers:
+- null

--- a/input/sources/tev-000012.yaml
+++ b/input/sources/tev-000012.yaml
@@ -1,0 +1,11 @@
+source_id: 12
+
+tevcat_id: 138
+tevcat2_id: y6gVxa
+tevcat_name: TeV J0223+430
+
+tgevcat_id: 12
+tgevcat_name: TeV J0223+4259
+
+papers:
+- null

--- a/input/sources/tev-000013.yaml
+++ b/input/sources/tev-000013.yaml
@@ -1,0 +1,11 @@
+source_id: 13
+
+tevcat_id: 130
+tevcat2_id: pVNsSZ
+tevcat_name: TeV J0232+202
+
+tgevcat_id: 13
+tgevcat_name: TeV J0232+2016
+
+papers:
+- null

--- a/input/sources/tev-000014.yaml
+++ b/input/sources/tev-000014.yaml
@@ -1,0 +1,11 @@
+source_id: 14
+
+tevcat_id: 89
+tevcat2_id: fW749W
+tevcat_name: TeV J0240+612
+
+tgevcat_id: 14
+tgevcat_name: TeV J0240+6115
+
+papers:
+- null

--- a/input/sources/tev-000015.yaml
+++ b/input/sources/tev-000015.yaml
@@ -1,0 +1,11 @@
+source_id: 15
+
+tevcat_id: 240
+tevcat2_id: 5puKGr
+tevcat_name: TeV J0303-241
+
+tgevcat_id: 15
+tgevcat_name: TeV J0303-2407
+
+papers:
+- null

--- a/input/sources/tev-000016.yaml
+++ b/input/sources/tev-000016.yaml
@@ -1,0 +1,11 @@
+source_id: 16
+
+tevcat_id: 208
+tevcat2_id: hooot9
+tevcat_name: TeV J0316+413
+
+tgevcat_id: 16
+tgevcat_name: TeV J0316+4119
+
+papers:
+- null

--- a/input/sources/tev-000017.yaml
+++ b/input/sources/tev-000017.yaml
@@ -1,0 +1,11 @@
+source_id: 17
+
+tevcat_id: 198
+tevcat2_id: p26X9Z
+tevcat_name: TeV J0319+187
+
+tgevcat_id: 17
+tgevcat_name: TeV J0319+1845
+
+papers:
+- null

--- a/input/sources/tev-000018.yaml
+++ b/input/sources/tev-000018.yaml
@@ -1,0 +1,11 @@
+source_id: 18
+
+tevcat_id: 212
+tevcat2_id: 9dfnMH
+tevcat_name: TeV J0319+415
+
+tgevcat_id: 18
+tgevcat_name: TeV J0319+4130
+
+papers:
+- null

--- a/input/sources/tev-000019.yaml
+++ b/input/sources/tev-000019.yaml
@@ -1,0 +1,11 @@
+source_id: 19
+
+tevcat_id: 147
+tevcat2_id: rWyLLM
+tevcat_name: TeV J0349-119
+
+tgevcat_id: 19
+tgevcat_name: TeV J0349-1158
+
+papers:
+- null

--- a/input/sources/tev-000020.yaml
+++ b/input/sources/tev-000020.yaml
@@ -1,0 +1,11 @@
+source_id: 20
+
+tevcat_id: 199
+tevcat2_id: hKCHxG
+tevcat_name: TeV J0416+010
+
+tgevcat_id: 20
+tgevcat_name: TeV J0416+0105
+
+papers:
+- null

--- a/input/sources/tev-000021.yaml
+++ b/input/sources/tev-000021.yaml
@@ -1,0 +1,11 @@
+source_id: 21
+
+tevcat_id: 203
+tevcat2_id: ewJQZd
+tevcat_name: TeV J0449-438
+
+tgevcat_id: 21
+tgevcat_name: TeV J0449-4350
+
+papers:
+- null

--- a/input/sources/tev-000022.yaml
+++ b/input/sources/tev-000022.yaml
@@ -1,0 +1,11 @@
+source_id: 22
+
+tevcat_id: 200
+tevcat2_id: 1G0nr7
+tevcat_name: TeV J0507+676
+
+tgevcat_id: 22
+tgevcat_name: TeV J0507+6737
+
+papers:
+- null

--- a/input/sources/tev-000023.yaml
+++ b/input/sources/tev-000023.yaml
@@ -1,0 +1,11 @@
+source_id: 23
+
+tevcat_id: 196
+tevcat2_id: ILT7om
+tevcat_name: TeV J0521+211
+
+tgevcat_id: 23
+tgevcat_name: TeV J0521+2112
+
+papers:
+- null

--- a/input/sources/tev-000024.yaml
+++ b/input/sources/tev-000024.yaml
@@ -1,0 +1,11 @@
+source_id: 24
+
+tevcat_id: 256
+tevcat2_id: z30txh
+tevcat_name: TeV J0525-696
+
+tgevcat_id: 24
+tgevcat_name: TeV J0525-6938
+
+papers:
+- null

--- a/input/sources/tev-000026.yaml
+++ b/input/sources/tev-000026.yaml
@@ -1,0 +1,11 @@
+source_id: 26
+
+tevcat_id: 255
+tevcat2_id: C6fp9j
+tevcat_name: TeV J0535-692
+
+tgevcat_id: 26
+tgevcat_name: TeV J0535-6911
+
+papers:
+- null

--- a/input/sources/tev-000027.yaml
+++ b/input/sources/tev-000027.yaml
@@ -1,0 +1,11 @@
+source_id: 27
+
+tevcat_id: 236
+tevcat2_id: 8hS5e7
+tevcat_name: TeV J0537-691
+
+tgevcat_id: 27
+tgevcat_name: TeV J0537-6909
+
+papers:
+- null

--- a/input/sources/tev-000028.yaml
+++ b/input/sources/tev-000028.yaml
@@ -1,0 +1,11 @@
+source_id: 28
+
+tevcat_id: 133
+tevcat2_id: U09cDa
+tevcat_name: TeV J0550-322
+
+tgevcat_id: 28
+tgevcat_name: TeV J0550-3216
+
+papers:
+- null

--- a/input/sources/tev-000029.yaml
+++ b/input/sources/tev-000029.yaml
@@ -1,0 +1,11 @@
+source_id: 29
+
+tevcat_id: 120
+tevcat2_id: 9xMcgD
+tevcat_name: TeV J0616+225
+
+tgevcat_id: 29
+tgevcat_name: TeV J0616+2230
+
+papers:
+- null

--- a/input/sources/tev-000030.yaml
+++ b/input/sources/tev-000030.yaml
@@ -1,0 +1,11 @@
+source_id: 30
+
+tevcat_id: 134
+tevcat2_id: jPeNQq
+tevcat_name: TeV J0632+058
+
+tgevcat_id: 30
+tgevcat_name: TeV J0632+0548
+
+papers:
+- null

--- a/input/sources/tev-000031.yaml
+++ b/input/sources/tev-000031.yaml
@@ -1,0 +1,11 @@
+source_id: 31
+
+tevcat_id: 177
+tevcat2_id: 66DvGb
+tevcat_name: TeV J0632+173
+
+tgevcat_id: 31
+tgevcat_name: TeV J0632+1722
+
+papers:
+- null

--- a/input/sources/tev-000032.yaml
+++ b/input/sources/tev-000032.yaml
@@ -1,0 +1,11 @@
+source_id: 32
+
+tevcat_id: 207
+tevcat2_id: 0WgN2s
+tevcat_name: TeV J0648+152
+
+tgevcat_id: 32
+tgevcat_name: TeV J0648+1516 #TeV J06481516
+
+papers:
+- null

--- a/input/sources/tev-000033.yaml
+++ b/input/sources/tev-000033.yaml
@@ -1,0 +1,11 @@
+source_id: 33
+
+tevcat_id: 238
+tevcat2_id: zp72d7
+tevcat_name: TeV J0650+250
+
+tgevcat_id: 33
+tgevcat_name: TeV J0650+2503
+
+papers:
+- null

--- a/input/sources/tev-000034.yaml
+++ b/input/sources/tev-000034.yaml
@@ -1,0 +1,11 @@
+source_id: 34
+
+tevcat_id: 173
+tevcat2_id: vejQq8
+tevcat_name: TeV J0710+591
+
+tgevcat_id: 34
+tgevcat_name: TeV J0710+5909
+
+papers:
+- null

--- a/input/sources/tev-000035.yaml
+++ b/input/sources/tev-000035.yaml
@@ -1,0 +1,11 @@
+source_id: 35
+
+tevcat_id: 172
+tevcat2_id: vDwoU3
+tevcat_name: TeV J0721+713
+
+tgevcat_id: 35
+tgevcat_name: TeV J0721+7120
+
+papers:
+- null

--- a/input/sources/tev-000036.yaml
+++ b/input/sources/tev-000036.yaml
@@ -1,0 +1,11 @@
+source_id: 36
+
+tevcat_id: 160
+tevcat2_id: kIwUzI
+tevcat_name: TeV J0809+523
+
+tgevcat_id: 36
+tgevcat_name: TeV J0809+5219
+
+papers:
+- null

--- a/input/sources/tev-000038.yaml
+++ b/input/sources/tev-000038.yaml
@@ -1,0 +1,11 @@
+source_id: 38
+
+tevcat_id: 249
+tevcat2_id: nhyiXQ
+tevcat_name: TeV J0847+115
+
+tgevcat_id: 38
+tgevcat_name: TeV J0847+1133
+
+papers:
+- null

--- a/input/sources/tev-000039.yaml
+++ b/input/sources/tev-000039.yaml
@@ -1,0 +1,11 @@
+source_id: 39
+
+tevcat_id: 98
+tevcat2_id: FfpuKQ
+tevcat_name: TeV J0852-463
+
+tgevcat_id: 39
+tgevcat_name: TeV J0852-4622
+
+papers:
+- null

--- a/input/sources/tev-000040.yaml
+++ b/input/sources/tev-000040.yaml
@@ -1,0 +1,11 @@
+source_id: 40
+
+tevcat_id: 194
+tevcat2_id: wN7SNs
+tevcat_name: TeV J0955+696
+
+tgevcat_id: 40
+tgevcat_name: TeV J0955+6940
+
+papers:
+- null

--- a/input/sources/tev-000041.yaml
+++ b/input/sources/tev-000041.yaml
@@ -1,0 +1,11 @@
+source_id: 41
+
+tevcat_id: 258
+tevcat2_id: null
+tevcat_name: TeV J0958+655
+
+tgevcat_id: 41
+tgevcat_name: TeV J0958+6533
+
+papers:
+- null

--- a/input/sources/tev-000042.yaml
+++ b/input/sources/tev-000042.yaml
@@ -1,0 +1,11 @@
+source_id: 42
+
+tevcat_id: 215
+tevcat2_id: 7fxWYa
+tevcat_name: TeV J1010-313
+
+tgevcat_id: 42
+tgevcat_name: TeV J1010-3118
+
+papers:
+- null

--- a/input/sources/tev-000043.yaml
+++ b/input/sources/tev-000043.yaml
@@ -1,0 +1,11 @@
+source_id: 43
+
+tevcat_id: 153
+tevcat2_id: agykYI
+tevcat_name: TeV J1015+494
+
+tgevcat_id: 43
+tgevcat_name: TeV J1015+4926
+
+papers:
+- null

--- a/input/sources/tev-000044.yaml
+++ b/input/sources/tev-000044.yaml
@@ -1,0 +1,11 @@
+source_id: 44
+
+tevcat_id: 260
+tevcat2_id: null
+tevcat_name: TeV J1016-589
+
+tgevcat_id: 44
+tgevcat_name: TeV J1016-5858
+
+papers:
+- null

--- a/input/sources/tev-000045.yaml
+++ b/input/sources/tev-000045.yaml
@@ -1,0 +1,11 @@
+source_id: 45
+
+tevcat_id: 237
+tevcat2_id: 5FlzLA
+tevcat_name: TeV J1018-589
+
+tgevcat_id: 45
+tgevcat_name: TeV J1018-5856
+
+papers:
+- null

--- a/input/sources/tev-000046.yaml
+++ b/input/sources/tev-000046.yaml
@@ -1,0 +1,11 @@
+source_id: 46
+
+tevcat_id: 132
+tevcat2_id: nvPEhx
+tevcat_name: TeV J1023-577
+
+tgevcat_id: 46
+tgevcat_name: TeV J1023-5747
+
+papers:
+- null

--- a/input/sources/tev-000047.yaml
+++ b/input/sources/tev-000047.yaml
@@ -1,0 +1,11 @@
+source_id: 47
+
+tevcat_id: 220
+tevcat2_id: UwjiUu
+tevcat_name: TeV J1026-582
+
+tgevcat_id: 47
+tgevcat_name: TeV J1026-5812
+
+papers:
+- null

--- a/input/sources/tev-000048.yaml
+++ b/input/sources/tev-000048.yaml
@@ -1,0 +1,11 @@
+source_id: 48
+
+tevcat_id: 97
+tevcat2_id: 2Z3QTH
+tevcat_name: TeV J1103-234
+
+tgevcat_id: 48
+tgevcat_name: TeV J1103-2329
+
+papers:
+- null

--- a/input/sources/tev-000050.yaml
+++ b/input/sources/tev-000050.yaml
@@ -1,0 +1,11 @@
+source_id: 50
+
+tevcat_id: 205
+tevcat2_id: 1wyMpL
+tevcat_name: TeV J1119-614
+
+tgevcat_id: 50
+tgevcat_name: TeV J1119-6124
+
+papers:
+- null

--- a/input/sources/tev-000051.yaml
+++ b/input/sources/tev-000051.yaml
@@ -1,0 +1,11 @@
+source_id: 51
+
+tevcat_id: 251
+tevcat2_id: 6T4fxx
+tevcat_name: TeV J1136+676
+
+tgevcat_id: 51
+tgevcat_name: TeV J1136+6737
+
+papers:
+- null

--- a/input/sources/tev-000052.yaml
+++ b/input/sources/tev-000052.yaml
@@ -1,0 +1,11 @@
+source_id: 52
+
+tevcat_id: 123
+tevcat2_id: mijtir
+tevcat_name: TeV J1136+701
+
+tgevcat_id: 52
+tgevcat_name: TeV J1136+7009
+
+papers:
+- null

--- a/input/sources/tev-000053.yaml
+++ b/input/sources/tev-000053.yaml
@@ -1,0 +1,11 @@
+source_id: 53
+
+tevcat_id: 219
+tevcat2_id: 891TG0
+tevcat_name: TeV J1217+301
+
+tgevcat_id: 53
+tgevcat_name: TeV J1217+3006
+
+papers:
+- null

--- a/input/sources/tev-000054.yaml
+++ b/input/sources/tev-000054.yaml
@@ -1,0 +1,11 @@
+source_id: 54
+
+tevcat_id: 159
+tevcat2_id: XQhcCi
+tevcat_name: TeV J1221+282
+
+tgevcat_id: 54
+tgevcat_name: TeV J1221+2813
+
+papers:
+- null

--- a/input/sources/tev-000055.yaml
+++ b/input/sources/tev-000055.yaml
@@ -1,0 +1,11 @@
+source_id: 55
+
+tevcat_id: 91
+tevcat2_id: urWmHx
+tevcat_name: TeV J1221+301
+
+tgevcat_id: 55
+tgevcat_name: TeV J1221+3011
+
+papers:
+- null

--- a/input/sources/tev-000056.yaml
+++ b/input/sources/tev-000056.yaml
@@ -1,0 +1,11 @@
+source_id: 56
+
+tevcat_id: 210
+tevcat2_id: dDaGC0
+tevcat_name: TeV J1224+213
+
+tgevcat_id: 56
+tgevcat_name: TeV J1224+2122
+
+papers:
+- null

--- a/input/sources/tev-000057.yaml
+++ b/input/sources/tev-000057.yaml
@@ -1,0 +1,11 @@
+source_id: 57
+
+tevcat_id: 245
+tevcat2_id: LpjBMP
+tevcat_name: TeV J1224+246
+
+tgevcat_id: 57
+tgevcat_name: TeV J1224+2436
+
+papers:
+- null

--- a/input/sources/tev-000059.yaml
+++ b/input/sources/tev-000059.yaml
@@ -1,0 +1,11 @@
+source_id: 59
+
+tevcat_id: 166
+tevcat2_id: YmUotO
+tevcat_name: TeV J1256-057
+
+tgevcat_id: 59
+tgevcat_name: TeV J1256-0547
+
+papers:
+- null

--- a/input/sources/tev-000060.yaml
+++ b/input/sources/tev-000060.yaml
@@ -1,0 +1,11 @@
+source_id: 60
+
+tevcat_id: 93
+tevcat2_id: HJQC5t
+tevcat_name: TeV J1302-638
+
+tgevcat_id: 60
+tgevcat_name: TeV J1302-6349
+
+papers:
+- null

--- a/input/sources/tev-000061.yaml
+++ b/input/sources/tev-000061.yaml
@@ -1,0 +1,11 @@
+source_id: 61
+
+tevcat_id: 94
+tevcat2_id: 4au9RH
+tevcat_name: TeV J1303-631
+
+tgevcat_id: 61
+tgevcat_name: TeV J1302-6310
+
+papers:
+- null

--- a/input/sources/tev-000062.yaml
+++ b/input/sources/tev-000062.yaml
@@ -1,0 +1,11 @@
+source_id: 62
+
+tevcat_id: 216
+tevcat2_id: 7uB4QE
+tevcat_name: TeV J1315-426
+
+tgevcat_id: 62
+tgevcat_name: TeV J1314-4235
+
+papers:
+- null

--- a/input/sources/tev-000063.yaml
+++ b/input/sources/tev-000063.yaml
@@ -1,0 +1,11 @@
+source_id: 63
+
+tevcat_id: 122
+tevcat2_id: ubPSXn
+tevcat_name: TeV J1325-430
+
+tgevcat_id: 63
+tgevcat_name: TeV J1325-4300
+
+papers:
+- null

--- a/input/sources/tev-000064.yaml
+++ b/input/sources/tev-000064.yaml
@@ -1,0 +1,11 @@
+source_id: 64
+
+tevcat_id: 170
+tevcat2_id: ms0x8h
+tevcat_name: TeV J1356-645
+
+tgevcat_id: 64
+tgevcat_name: TeV J1356-6430
+
+papers:
+- null

--- a/input/sources/tev-000065.yaml
+++ b/input/sources/tev-000065.yaml
@@ -1,0 +1,11 @@
+source_id: 65
+
+tevcat_id: 125
+tevcat2_id: r1X1KA
+tevcat_name: TeV J1418-609
+
+tgevcat_id: 65
+tgevcat_name: TeV J1418-6058
+
+papers:
+- null

--- a/input/sources/tev-000066.yaml
+++ b/input/sources/tev-000066.yaml
@@ -1,0 +1,11 @@
+source_id: 66
+
+tevcat_id: 124
+tevcat2_id: zUDsnw
+tevcat_name: TeV J1420-607
+
+tgevcat_id: 66
+tgevcat_name: TeV J1420-6045
+
+papers:
+- null

--- a/input/sources/tev-000067.yaml
+++ b/input/sources/tev-000067.yaml
@@ -1,0 +1,11 @@
+source_id: 67
+
+tevcat_id: 184
+tevcat2_id: lGHxlE
+tevcat_name: TeV J1427+238
+
+tgevcat_id: 67
+tgevcat_name: TeV J1427+2347 #TeV J14272347
+
+papers:
+- null

--- a/input/sources/tev-000068.yaml
+++ b/input/sources/tev-000068.yaml
@@ -1,0 +1,11 @@
+source_id: 68
+
+tevcat_id: 139
+tevcat2_id: eee9un
+tevcat_name: TeV J1427-608
+
+tgevcat_id: 68
+tgevcat_name: TeV J1427-6051
+
+papers:
+- null

--- a/input/sources/tev-000070.yaml
+++ b/input/sources/tev-000070.yaml
@@ -1,0 +1,11 @@
+source_id: 70
+
+tevcat_id: 168
+tevcat2_id: gc4bRT
+tevcat_name: TeV J1442-624
+
+tgevcat_id: 70
+tgevcat_name: TeV J1442-6226
+
+papers:
+- null

--- a/input/sources/tev-000071.yaml
+++ b/input/sources/tev-000071.yaml
@@ -1,0 +1,11 @@
+source_id: 71
+
+tevcat_id: 85
+tevcat2_id: 57tu8J
+tevcat_name: TeV J1443+120
+
+tgevcat_id: 71
+tgevcat_name: TeV J1442+1200
+
+papers:
+- null

--- a/input/sources/tev-000072.yaml
+++ b/input/sources/tev-000072.yaml
@@ -1,0 +1,11 @@
+source_id: 72
+
+tevcat_id: 222
+tevcat2_id: MN9aoz
+tevcat_name: TeV J1457-594
+
+tgevcat_id: 72
+tgevcat_name: TeV J1457-5928
+
+papers:
+- null

--- a/input/sources/tev-000073.yaml
+++ b/input/sources/tev-000073.yaml
@@ -1,0 +1,11 @@
+source_id: 73
+
+tevcat_id: 241
+tevcat2_id: hksZjo
+tevcat_name: TeV J1459-608
+
+tgevcat_id: 73
+tgevcat_name: TeV J1458-6052
+
+papers:
+- null

--- a/input/sources/tev-000074.yaml
+++ b/input/sources/tev-000074.yaml
@@ -1,0 +1,11 @@
+source_id: 74
+
+tevcat_id: 171
+tevcat2_id: lys1PH
+tevcat_name: TeV J1502-421
+
+tgevcat_id: 74
+tgevcat_name: TeV J1502-4107
+
+papers:
+- null

--- a/input/sources/tev-000075.yaml
+++ b/input/sources/tev-000075.yaml
@@ -1,0 +1,11 @@
+source_id: 75
+
+tevcat_id: 169
+tevcat2_id: LuGtCl
+tevcat_name: TeV J1503-582
+
+tgevcat_id: 75
+tgevcat_name: TeV J1503-5813
+
+papers:
+- null

--- a/input/sources/tev-000076.yaml
+++ b/input/sources/tev-000076.yaml
@@ -1,0 +1,11 @@
+source_id: 76
+
+tevcat_id: 221
+tevcat2_id: JbSjYy
+tevcat_name: TeV J1504-418
+
+tgevcat_id: 76
+tgevcat_name: TeV J1504-4148
+
+papers:
+- null

--- a/input/sources/tev-000077.yaml
+++ b/input/sources/tev-000077.yaml
@@ -1,0 +1,11 @@
+source_id: 77
+
+tevcat_id: 204
+tevcat2_id: jNYEaw
+tevcat_name: TeV J1506-623
+
+tgevcat_id: 77
+tgevcat_name: TeV J1506-6221
+
+papers:
+- null

--- a/input/sources/tev-000078.yaml
+++ b/input/sources/tev-000078.yaml
@@ -1,0 +1,11 @@
+source_id: 78
+
+tevcat_id: 206
+tevcat2_id: hptayL
+tevcat_name: TeV J1512-091
+
+tgevcat_id: 78
+tgevcat_name: TeV J1512-0906
+
+papers:
+- null

--- a/input/sources/tev-000079.yaml
+++ b/input/sources/tev-000079.yaml
@@ -1,0 +1,11 @@
+source_id: 79
+
+tevcat_id: 95
+tevcat2_id: OhJ7Hr
+tevcat_name: TeV J1514-591
+
+tgevcat_id: 79
+tgevcat_name: TeV J1513-5914
+
+papers:
+- null

--- a/input/sources/tev-000080.yaml
+++ b/input/sources/tev-000080.yaml
@@ -1,0 +1,11 @@
+source_id: 80
+
+tevcat_id: 202
+tevcat2_id: qpaBdR
+tevcat_name: TeV J1517-243
+
+tgevcat_id: 80
+tgevcat_name: TeV J1517-2422
+
+papers:
+- null

--- a/input/sources/tev-000081.yaml
+++ b/input/sources/tev-000081.yaml
@@ -1,0 +1,11 @@
+source_id: 81
+
+tevcat_id: 235
+tevcat2_id: Xq3nlo
+tevcat_name: 	TeV J1554-550
+
+tgevcat_id: 81
+tgevcat_name: TeV J1554-5505
+
+papers:
+- null

--- a/input/sources/tev-000082.yaml
+++ b/input/sources/tev-000082.yaml
@@ -1,0 +1,11 @@
+source_id: 82
+
+tevcat_id: 102
+tevcat2_id: ffHtfX
+tevcat_name: TeV J1555+111
+
+tgevcat_id: 82
+tgevcat_name: TeV J1555+1111
+
+papers:
+- null

--- a/input/sources/tev-000084.yaml
+++ b/input/sources/tev-000084.yaml
@@ -1,0 +1,11 @@
+source_id: 84
+
+tevcat_id: 104
+tevcat2_id: 2m5UkC
+tevcat_name: TeV J1616-508
+
+tgevcat_id: 84
+tgevcat_name: TeV J1616-5054
+
+papers:
+- null

--- a/input/sources/tev-000085.yaml
+++ b/input/sources/tev-000085.yaml
@@ -1,0 +1,11 @@
+source_id: 85
+
+tevcat_id: 137
+tevcat2_id: ctBOIp
+tevcat_name: TeV J1626-490
+
+tgevcat_id: 85
+tgevcat_name: TeV J1626-4905
+
+papers:
+- null

--- a/input/sources/tev-000086.yaml
+++ b/input/sources/tev-000086.yaml
@@ -1,0 +1,11 @@
+source_id: 86
+
+tevcat_id: 105
+tevcat2_id: p9DNQ0
+tevcat_name: TeV J1632-478
+
+tgevcat_id: 86
+tgevcat_name: TeV J1632-4749
+
+papers:
+- null

--- a/input/sources/tev-000087.yaml
+++ b/input/sources/tev-000087.yaml
@@ -1,0 +1,11 @@
+source_id: 87
+
+tevcat_id: 106
+tevcat2_id: qne6F2
+tevcat_name: TeV J1634-472
+
+tgevcat_id: 87
+tgevcat_name: TeV J1634-4716
+
+papers:
+- null

--- a/input/sources/tev-000088.yaml
+++ b/input/sources/tev-000088.yaml
@@ -1,0 +1,11 @@
+source_id: 88
+
+tevcat_id: 107
+tevcat2_id: QAgfnh
+tevcat_name: TeV J1640-465
+
+tgevcat_id: 88
+tgevcat_name: TeV J1640-4631
+
+papers:
+- null

--- a/input/sources/tev-000089.yaml
+++ b/input/sources/tev-000089.yaml
@@ -1,0 +1,11 @@
+source_id: 89
+
+tevcat_id: 243
+tevcat2_id: oeIIrE
+tevcat_name: TeV J1641-463
+
+tgevcat_id: 89
+tgevcat_name: TeV J1641-4618
+
+papers:
+- null

--- a/input/sources/tev-000090.yaml
+++ b/input/sources/tev-000090.yaml
@@ -1,0 +1,11 @@
+source_id: 90
+
+tevcat_id: 186
+tevcat2_id: Lv6nKy
+tevcat_name: TeV J1647-458
+
+tgevcat_id: 90
+tgevcat_name: TeV J1646-4549
+
+papers:
+- null

--- a/input/sources/tev-000092.yaml
+++ b/input/sources/tev-000092.yaml
@@ -1,0 +1,11 @@
+source_id: 92
+
+tevcat_id: 108
+tevcat2_id: B41Y7y
+tevcat_name: TeV J1702-420
+
+tgevcat_id: 92
+tgevcat_name: TeV J1702-4200
+
+papers:
+- null

--- a/input/sources/tev-000093.yaml
+++ b/input/sources/tev-000093.yaml
@@ -1,0 +1,11 @@
+source_id: 93
+
+tevcat_id: 109
+tevcat2_id: xGSgEi
+tevcat_name: TeV J1708-410
+
+tgevcat_id: 93
+tgevcat_name: TeV J1708-4105
+
+papers:
+- null

--- a/input/sources/tev-000094.yaml
+++ b/input/sources/tev-000094.yaml
@@ -1,0 +1,11 @@
+source_id: 94
+
+tevcat_id: 191
+tevcat2_id: jrf7QE
+tevcat_name: TeV J1708-443
+
+tgevcat_id: 94
+tgevcat_name: TeV J1708-4420
+
+papers:
+- null

--- a/input/sources/tev-000095.yaml
+++ b/input/sources/tev-000095.yaml
@@ -1,0 +1,11 @@
+source_id: 95
+
+tevcat_id: 110
+tevcat2_id: QYavG5
+tevcat_name: TeV J1713-382
+
+tgevcat_id: 95
+tgevcat_name: TeV J1713-3811
+
+papers:
+- null

--- a/input/sources/tev-000097.yaml
+++ b/input/sources/tev-000097.yaml
@@ -1,0 +1,11 @@
+source_id: 97
+
+tevcat_id: 158
+tevcat2_id: Mk4fht
+tevcat_name: TeV J1714-385
+
+tgevcat_id: 97
+tgevcat_name: TeV J1714-3834
+
+papers:
+- null

--- a/input/sources/tev-000098.yaml
+++ b/input/sources/tev-000098.yaml
@@ -1,0 +1,11 @@
+source_id: 98
+
+tevcat_id: 250
+tevcat2_id: D5Wki5
+tevcat_name: TeV J1718-374
+
+tgevcat_id: 98
+tgevcat_name: TeV J1717-3726
+
+papers:
+- null

--- a/input/sources/tev-000099.yaml
+++ b/input/sources/tev-000099.yaml
@@ -1,0 +1,11 @@
+source_id: 99
+
+tevcat_id: 154
+tevcat2_id: iq0QXk
+tevcat_name: TeV J1718-385
+
+tgevcat_id: 99
+tgevcat_name: TeV J1718-3833
+
+papers:
+- null

--- a/input/sources/tev-000100.yaml
+++ b/input/sources/tev-000100.yaml
@@ -1,0 +1,11 @@
+source_id: 100
+
+tevcat_id: 246
+tevcat2_id: neQBRF
+tevcat_name: TeV 1725+118
+
+tgevcat_id: 100
+tgevcat_name: TeV J1725+1152
+
+papers:
+- null

--- a/input/sources/tev-000101.yaml
+++ b/input/sources/tev-000101.yaml
@@ -1,0 +1,11 @@
+source_id: 101
+
+tevcat_id: 232
+tevcat2_id: 9xaXCk
+tevcat_name: TeV J1728+502
+
+tgevcat_id: 101
+tgevcat_name: TeV J1728+5013
+
+papers:
+- null

--- a/input/sources/tev-000102.yaml
+++ b/input/sources/tev-000102.yaml
@@ -1,0 +1,11 @@
+source_id: 102
+
+tevcat_id: 224
+tevcat2_id: UnsKSi
+tevcat_name: TeV J1729-345
+
+tgevcat_id: 102
+tgevcat_name: TeV J1729-3432
+
+papers:
+- null

--- a/input/sources/tev-000103.yaml
+++ b/input/sources/tev-000103.yaml
@@ -1,0 +1,11 @@
+source_id: 103
+
+tevcat_id: 141
+tevcat2_id: mrGXwA
+tevcat_name: TeV J1732-347
+
+tgevcat_id: 103
+tgevcat_name: TeV J1732-3445
+
+papers:
+- null

--- a/input/sources/tev-000104.yaml
+++ b/input/sources/tev-000104.yaml
@@ -1,0 +1,11 @@
+source_id: 104
+
+tevcat_id: 189
+tevcat2_id: JPcqWZ
+tevcat_name: TeV J1741-301
+
+tgevcat_id: 104
+tgevcat_name: TeV J1741-3012
+
+papers:
+- null

--- a/input/sources/tev-000105.yaml
+++ b/input/sources/tev-000105.yaml
@@ -1,0 +1,11 @@
+source_id: 105
+
+tevcat_id: 225
+tevcat2_id: Y4DogE
+tevcat_name: TeV J1743+196
+
+tgevcat_id: 105
+tgevcat_name: TeV J1743+1935
+
+papers:
+- null

--- a/input/sources/tev-000107.yaml
+++ b/input/sources/tev-000107.yaml
@@ -1,0 +1,11 @@
+source_id: 107
+
+tevcat_id: 121
+tevcat2_id: PehQOM
+tevcat_name: TeV J1745-290d
+
+tgevcat_id: 107
+tgevcat_name: TeV J1745-2900
+
+papers:
+- null

--- a/input/sources/tev-000108.yaml
+++ b/input/sources/tev-000108.yaml
@@ -1,0 +1,11 @@
+source_id: 108
+
+tevcat_id: 111
+tevcat2_id: Gmuzgm
+tevcat_name: TeV J1745-303
+
+tgevcat_id: 108
+tgevcat_name: TeV J1745-3022
+
+papers:
+- null

--- a/input/sources/tev-000109.yaml
+++ b/input/sources/tev-000109.yaml
@@ -1,0 +1,11 @@
+source_id: 109
+
+tevcat_id: 234
+tevcat2_id: xhmRbS
+tevcat_name: TeV J1747-248
+
+tgevcat_id: 109
+tgevcat_name: TeV J1747-2448
+
+papers:
+- null

--- a/input/sources/tev-000110.yaml
+++ b/input/sources/tev-000110.yaml
@@ -1,0 +1,11 @@
+source_id: 110
+
+tevcat_id: 112
+tevcat2_id: jvz6ag
+tevcat_name: TeV J1747-281
+
+tgevcat_id: 110
+tgevcat_name: TeV J1747-2809
+
+papers:
+- null

--- a/input/sources/tev-000112.yaml
+++ b/input/sources/tev-000112.yaml
@@ -1,0 +1,11 @@
+source_id: 112
+
+tevcat_id: 162
+tevcat2_id: jcVLu0
+tevcat_name: TeV J1801-233
+
+tgevcat_id: 112
+tgevcat_name: TeV J1801-2320
+
+papers:
+- null

--- a/input/sources/tev-000113.yaml
+++ b/input/sources/tev-000113.yaml
@@ -1,0 +1,11 @@
+source_id: 113
+
+tevcat_id: 113
+tevcat2_id: y1kNQO
+tevcat_name: TeV J1804-217
+
+tgevcat_id: 113
+tgevcat_name: TeV J1804-2143
+
+papers:
+- null

--- a/input/sources/tev-000114.yaml
+++ b/input/sources/tev-000114.yaml
@@ -1,0 +1,11 @@
+source_id: 114
+
+tevcat_id: 242
+tevcat2_id: Ere9PS
+tevcat_name: TeV J1808-204
+
+tgevcat_id: 114
+tgevcat_name: TeV J1808-2026
+
+papers:
+- null

--- a/input/sources/tev-000115.yaml
+++ b/input/sources/tev-000115.yaml
@@ -1,0 +1,11 @@
+source_id: 115
+
+tevcat_id: 155
+tevcat2_id: OWsjG1
+tevcat_name: TeV J1810-193
+
+tgevcat_id: 115
+tgevcat_name: TeV J1810-1918
+
+papers:
+- null

--- a/input/sources/tev-000116.yaml
+++ b/input/sources/tev-000116.yaml
@@ -1,0 +1,11 @@
+source_id: 116
+
+tevcat_id: 114
+tevcat2_id: Unhlxa
+tevcat_name: TeV J1813-178
+
+tgevcat_id: 116
+tgevcat_name: TeV J1813-1750
+
+papers:
+- null

--- a/input/sources/tev-000117.yaml
+++ b/input/sources/tev-000117.yaml
@@ -1,0 +1,11 @@
+source_id: 117
+
+tevcat_id: 233
+tevcat2_id: SxYdrN
+tevcat_name: TeV J1818-154
+
+tgevcat_id: 117
+tgevcat_name: TeV J1818-1528
+
+papers:
+- null

--- a/input/sources/tev-000118.yaml
+++ b/input/sources/tev-000118.yaml
@@ -1,0 +1,11 @@
+source_id: 118
+
+tevcat_id: 115
+tevcat2_id: xnwQAv
+tevcat_name: TeV J1826-137
+
+tgevcat_id: 118
+tgevcat_name: TeV J1825-1350
+
+papers:
+- null

--- a/input/sources/tev-000119.yaml
+++ b/input/sources/tev-000119.yaml
@@ -1,0 +1,11 @@
+source_id: 119
+
+tevcat_id: 96
+tevcat2_id: xKaTtF
+tevcat_name: TeV J1826-148
+
+tgevcat_id: 119
+tgevcat_name: TeV J1826-1449
+
+papers:
+- null

--- a/input/sources/tev-000120.yaml
+++ b/input/sources/tev-000120.yaml
@@ -1,0 +1,11 @@
+source_id: 120
+
+tevcat_id: 231
+tevcat2_id: buLRDe
+tevcat_name: TeV J1831-099
+
+tgevcat_id: 120
+tgevcat_name: TeV J1831-0954
+
+papers:
+- null

--- a/input/sources/tev-000121.yaml
+++ b/input/sources/tev-000121.yaml
@@ -1,0 +1,11 @@
+source_id: 122
+
+tevcat_id: 230
+tevcat2_id: 1aPLDl
+tevcat_name: TeV J1832-093
+
+tgevcat_id: 122
+tgevcat_name: TeV J1832-0922
+
+papers:
+- null

--- a/input/sources/tev-000122.yaml
+++ b/input/sources/tev-000122.yaml
@@ -1,0 +1,11 @@
+source_id: 122
+
+tevcat_id: 140
+tevcat2_id: EmvcSG
+tevcat_name: TeV J1833-105
+
+tgevcat_id: 122
+tgevcat_name: TeV J1833-1033
+
+papers:
+- null

--- a/input/sources/tev-000123.yaml
+++ b/input/sources/tev-000123.yaml
@@ -1,0 +1,11 @@
+source_id: 123
+
+tevcat_id: 116
+tevcat2_id: 4xiQfb
+tevcat_name: TeV J1834-087
+
+tgevcat_id: 123
+tgevcat_name: TeV J1834-0845
+
+papers:
+- null

--- a/input/sources/tev-000124.yaml
+++ b/input/sources/tev-000124.yaml
@@ -1,0 +1,11 @@
+source_id: 124
+
+tevcat_id: 117
+tevcat2_id: giVWlK
+tevcat_name: TeV J1837-069
+
+tgevcat_id: 124
+tgevcat_name: TeV J1837-0656
+
+papers:
+- null

--- a/input/sources/tev-000125.yaml
+++ b/input/sources/tev-000125.yaml
@@ -1,0 +1,11 @@
+source_id: 125
+
+tevcat_id: 142
+tevcat2_id: amNIwH
+tevcat_name: TeV J1840-055
+
+tgevcat_id: 125
+tgevcat_name: TeV J1840-0533
+
+papers:
+- null

--- a/input/sources/tev-000126.yaml
+++ b/input/sources/tev-000126.yaml
@@ -1,0 +1,11 @@
+source_id: 126
+
+tevcat_id: 190
+tevcat2_id: DTC72E
+tevcat_name: TeV J1843-030
+
+tgevcat_id: 126
+tgevcat_name: TeV J1843-0318
+
+papers:
+- null

--- a/input/sources/tev-000127.yaml
+++ b/input/sources/tev-000127.yaml
@@ -1,0 +1,11 @@
+source_id: 127
+
+tevcat_id: 167
+tevcat2_id: Ipmg1A
+tevcat_name: TeV J1846-029
+
+tgevcat_id: 127
+tgevcat_name: TeV J1846-0258
+
+papers:
+- null

--- a/input/sources/tev-000128.yaml
+++ b/input/sources/tev-000128.yaml
@@ -1,0 +1,11 @@
+source_id: 128
+
+tevcat_id: 187
+tevcat2_id: hcE3Ou
+tevcat_name: TeV J1848-017
+
+tgevcat_id: 128
+tgevcat_name: TeV J1848-0147
+
+papers:
+- null

--- a/input/sources/tev-000129.yaml
+++ b/input/sources/tev-000129.yaml
@@ -1,0 +1,11 @@
+source_id: 129
+
+tevcat_id: 188
+tevcat2_id: 8nWF6I
+tevcat_name: TeV J1849-000
+
+tgevcat_id: 129
+tgevcat_name: TeV J1849-0001
+
+papers:
+- null

--- a/input/sources/tev-000130.yaml
+++ b/input/sources/tev-000130.yaml
@@ -1,0 +1,11 @@
+source_id: 130
+
+tevcat_id: 143
+tevcat2_id: BDIaeo
+tevcat_name: TeV J1857+026
+
+tgevcat_id: 130
+tgevcat_name: TeV J1857+0242
+
+papers:
+- null

--- a/input/sources/tev-000131.yaml
+++ b/input/sources/tev-000131.yaml
@@ -1,0 +1,11 @@
+source_id: 131
+
+tevcat_id: 144
+tevcat2_id: KxJfNI
+tevcat_name: TeV J1858+020
+
+tgevcat_id: 131
+tgevcat_name: TeV J1858+0205
+
+papers:
+- null

--- a/input/sources/tev-000132.yaml
+++ b/input/sources/tev-000132.yaml
@@ -1,0 +1,11 @@
+source_id: 132
+
+tevcat_id: 148
+tevcat2_id: eaYOuH
+tevcat_name: TeV J1907+062
+
+tgevcat_id: 132
+tgevcat_name: TeV J1907+0613
+
+papers:
+- null

--- a/input/sources/tev-000133.yaml
+++ b/input/sources/tev-000133.yaml
@@ -1,0 +1,11 @@
+source_id: 133
+
+tevcat_id: 218
+tevcat2_id: tHQw4n
+tevcat_name: TeV J1911+090
+
+tgevcat_id: 133
+tgevcat_name: TeV J1911+0905
+
+papers:
+- null

--- a/input/sources/tev-000134.yaml
+++ b/input/sources/tev-000134.yaml
@@ -1,0 +1,11 @@
+source_id: 134
+
+tevcat_id: 157
+tevcat2_id: J26r5R
+tevcat_name: TeV J1912+101
+
+tgevcat_id: 134
+tgevcat_name: TeV J1912+1009
+
+papers:
+- null

--- a/input/sources/tev-000135.yaml
+++ b/input/sources/tev-000135.yaml
@@ -1,0 +1,11 @@
+source_id: 135
+
+tevcat_id: 178
+tevcat2_id: ParXkE
+tevcat_name: TeV J1923+141
+
+tgevcat_id: 135
+tgevcat_name: TeV J1922+1411
+
+papers:
+- null

--- a/input/sources/tev-000136.yaml
+++ b/input/sources/tev-000136.yaml
@@ -1,0 +1,11 @@
+source_id: 136
+
+tevcat_id: 193
+tevcat2_id: F0Luol
+tevcat_name: TeV J1930+188
+
+tgevcat_id: 136
+tgevcat_name: TeV J1930+1852
+
+papers:
+- null

--- a/input/sources/tev-000137.yaml
+++ b/input/sources/tev-000137.yaml
@@ -1,0 +1,11 @@
+source_id: 137
+
+tevcat_id: 214
+tevcat2_id: RdzX69
+tevcat_name: TeV J1943+213
+
+tgevcat_id: 137
+tgevcat_name: TeV J1943+2118
+
+papers:
+- null

--- a/input/sources/tev-000139.yaml
+++ b/input/sources/tev-000139.yaml
@@ -1,0 +1,11 @@
+source_id: 139
+
+tevcat_id: 165
+tevcat2_id: ljNqkw
+tevcat_name: TeV J2001+438
+
+tgevcat_id: 139
+tgevcat_name: TeV J2001+4353
+
+papers:
+- null

--- a/input/sources/tev-000140.yaml
+++ b/input/sources/tev-000140.yaml
@@ -1,0 +1,11 @@
+source_id: 140
+
+tevcat_id: 100
+tevcat2_id: ObIXbg
+tevcat_name: TeV J2009-488
+
+tgevcat_id: 140
+tgevcat_name: TeV J2009-4849
+
+papers:
+- null

--- a/input/sources/tev-000141.yaml
+++ b/input/sources/tev-000141.yaml
@@ -1,0 +1,11 @@
+source_id: 141
+
+tevcat_id: 228
+tevcat2_id: wbkK3X
+tevcat_name: TeV J2016+372
+
+tgevcat_id: 141
+tgevcat_name: TeV J2016+3711
+
+papers:
+- null

--- a/input/sources/tev-000142.yaml
+++ b/input/sources/tev-000142.yaml
@@ -1,0 +1,11 @@
+source_id: 142
+
+tevcat_id: 145
+tevcat2_id: RZ7qzv
+tevcat_name: TeV J2019+368
+
+tgevcat_id: 142
+tgevcat_name: TeV J2018+3642
+
+papers:
+- null

--- a/input/sources/tev-000143.yaml
+++ b/input/sources/tev-000143.yaml
@@ -1,0 +1,11 @@
+source_id: 143
+
+tevcat_id: 259
+tevcat2_id: null
+tevcat_name: TeV J2019+368
+
+tgevcat_id: 143
+tgevcat_name: TeV J2019+3648
+
+papers:
+- null

--- a/input/sources/tev-000144.yaml
+++ b/input/sources/tev-000144.yaml
@@ -1,0 +1,11 @@
+source_id: 144
+
+tevcat_id: 201
+tevcat2_id: IWrXQp
+tevcat_name: TeV J2019+407
+
+tgevcat_id: 144
+tgevcat_name: TeV J2020+4045
+
+papers:
+- null

--- a/input/sources/tev-000145.yaml
+++ b/input/sources/tev-000145.yaml
@@ -1,0 +1,11 @@
+source_id: 145
+
+tevcat_id: 149
+tevcat2_id: 1FCN0q
+tevcat_name: TeV J2031+406
+
+tgevcat_id: 145
+tgevcat_name: TeV J2031+4040
+
+papers:
+- null

--- a/input/sources/tev-000147.yaml
+++ b/input/sources/tev-000147.yaml
@@ -1,0 +1,11 @@
+source_id: 147
+
+tevcat_id: 90
+tevcat2_id: nm0IZL
+tevcat_name: TeV J2158-302
+
+tgevcat_id: 147
+tgevcat_name: TeV J2158-3013
+
+papers:
+- null

--- a/input/sources/tev-000148.yaml
+++ b/input/sources/tev-000148.yaml
@@ -1,0 +1,11 @@
+source_id: 148
+
+tevcat_id: 118
+tevcat2_id: iIWshp
+tevcat_name: TeV J2202+422
+
+tgevcat_id: 148
+tgevcat_name: TeV J2202+4216
+
+papers:
+- null

--- a/input/sources/tev-000150.yaml
+++ b/input/sources/tev-000150.yaml
@@ -1,0 +1,11 @@
+source_id: 150
+
+tevcat_id: 182
+tevcat2_id: qsRoN6
+tevcat_name: TeV J2228+611
+
+tgevcat_id: 150
+tgevcat_name: TeV J2228+6110
+
+papers:
+- null

--- a/input/sources/tev-000151.yaml
+++ b/input/sources/tev-000151.yaml
@@ -1,0 +1,11 @@
+source_id: 151
+
+tevcat_id: 257
+tevcat2_id: 7IL8zC
+tevcat_name: TeV J2243+203
+
+tgevcat_id: 151
+tgevcat_name: TeV J2243+2021
+
+papers:
+- null

--- a/input/sources/tev-000152.yaml
+++ b/input/sources/tev-000152.yaml
@@ -1,0 +1,11 @@
+source_id: 152
+
+tevcat_id: 211
+tevcat2_id: WCU2Cw
+tevcat_name: TeV J2250+384
+
+tgevcat_id: 152
+tgevcat_name: TeV J2250+3824
+
+papers:
+- null

--- a/input/sources/tev-000155.yaml
+++ b/input/sources/tev-000155.yaml
@@ -1,0 +1,11 @@
+source_id: 155
+
+tevcat_id: 101
+tevcat2_id: VIbvxm
+tevcat_name: TeV J2359-306
+
+tgevcat_id: 155
+tgevcat_name: TeV J2359-3037
+
+papers:
+- null


### PR DESCRIPTION
In this PR, I've created the other yaml files for the sources. Some issues:

* Any tevcat id beyond 257 did not have a tevcat2 id (the URL doesn't redirect). For these sources, I left the tevcat2_id field as `null`.

* [tevcat id 129](https://github.com/gammapy/gamma-cat/blob/master/seed/tevcat/tevcat.ecsv#L64) is unpaired with any tgevcat source, but is SIMILAR to [tevcat id 74](https://github.com/gammapy/gamma-cat/blob/master/seed/tevcat/tevcat.ecsv#L16) (which is paired).

* tevcat id [163](https://github.com/gammapy/gamma-cat/blob/master/seed/tevcat/tevcat.ecsv#L89) and [164](https://github.com/gammapy/gamma-cat/blob/master/seed/tevcat/tevcat.ecsv#L90) are unpaired, because tgevcat "combines" these two with [tgevcat id 111](https://github.com/gammapy/gamma-cat/blob/master/seed/tgevcat/tgevcat.ecsv#L173).

* [tevcat id 261](https://github.com/gammapy/gamma-cat/blob/master/seed/tevcat/tevcat.ecsv#L146) is unpaired. One of its alternative names does appear on [tgevcat id 145](https://github.com/gammapy/gamma-cat/blob/master/seed/tgevcat/tgevcat.ecsv#L207), but this is paired with ANOTHER tevcat source ([id 149](https://github.com/gammapy/gamma-cat/blob/master/seed/tevcat/tevcat.ecsv#L79)).

* Same issue as above for both tevcat id [278](https://github.com/gammapy/gamma-cat/blob/master/seed/tevcat/tevcat.ecsv#L148) and [279](https://github.com/gammapy/gamma-cat/blob/master/seed/tevcat/tevcat.ecsv#L149) - they match up with [tgevcat id 130](https://github.com/gammapy/gamma-cat/blob/master/seed/tgevcat/tgevcat.ecsv#L192), but that's already paired with [tevcat id 143](https://github.com/gammapy/gamma-cat/blob/master/seed/tevcat/tevcat.ecsv#L74).

* Same issue again with [tevcat id 253](https://github.com/gammapy/gamma-cat/blob/master/seed/tevcat/tevcat.ecsv#L175) - it matches with [tgevcat id 37](https://github.com/gammapy/gamma-cat/blob/master/seed/tgevcat/tgevcat.ecsv#L99), but that's already paired with [tevcat id 86](https://github.com/gammapy/gamma-cat/blob/master/seed/tevcat/tevcat.ecsv#L26).

* These are the other tevcat sources that simply do not have a tgevcat counterpart at all: 88, 174, 263-274, 277, 280.

Sorry if that's a bit confusing.

The reason I couldn't fill in most of these missing fields as "null" is because if there isn't a tgevcat source to match, I don't know what to call the file (our id depends on tgevcat's source id).

Other than that, all of the files in this PR should be just fine. I did check them over throughout to make sure I wasn't making any mistakes.