### PR TITLE
Add HESS, W49B, 2016arXiv160900600H

### DIFF
--- a/input/papers/2016/2016arXiv160900600H/tev-000133.ecsv
+++ b/input/papers/2016/2016arXiv160900600H/tev-000133.ecsv
@@ -1,0 +1,23 @@
+# %ECSV 0.9
+# ---
+# datatype:
+# - {name: e_ref, datatype: float32}
+# - {name: e_lo, datatype: float32}
+# - {name: e_hi, datatype: float32}
+# - {name: dnde, datatype: float32}
+# - {name: dnde_errn, datatype: float32}
+# - {name: dnde_errp, datatype: float32}
+# meta: !!omap
+# - source_id: 133
+# - paper_id: 2016arXiv160900600H
+# - comments: |
+#     Data from Francois Brun via email Nov 4, 2016
+#     The last point has an error of 0, this is an UL at 95% CL.
+#     In the figures of the paper, systematic error of 20% of the
+#     flux value has been added in quadrature to the statistical error of each point.
+e_ref e_lo e_hi dnde dnde_errn dnde_errp
+0.406 0.1138 0.0741 4.791e-12 1.303e-12 1.377e-12
+0.5982 0.1181 0.1907 1.675e-12 2.57e-13 2.66e-13
+0.9658 0.1769 0.3302 3.208e-13 8.07e-14 8.52e-14
+1.579 0.283 0.551 8.466e-14 3.018e-14 3.234e-14
+3.918 1.788 109.282 9.539e-15 nan nan

--- a/input/papers/2016/2016arXiv160900600H/tev-000133.yaml
+++ b/input/papers/2016/2016arXiv160900600H/tev-000133.yaml
@@ -1,0 +1,29 @@
+paper_id: 2016arXiv160900600H
+source_id: 133
+
+data:
+  livetime: 75
+  zenith: 37
+  offset: 1.1
+  n_on: 1141
+  n_off: 16017
+  alpha: 0.047
+  excess: 392
+  significance: 12.9
+
+pos:
+  # from two-source fit (point for W49B)
+  glon: {val: 43.260, err: 0.005, err_sys: 0.006}
+  glat: {val: -0.190, err: 0.005, err_sys: 0.006}
+
+morph:
+  type: point
+
+spec:
+  type: pl
+  norm: {val: 0.315, err: 0.046, err_sys: 0.063}
+  index: {val: 3.14, err: 0.24, err_sys: 0.29}
+  ref: 1
+
+  theta: 0.1
+  erange: {min: 0.29}

--- a/input/schemas/paper_source_info.schema.yaml
+++ b/input/schemas/paper_source_info.schema.yaml
@@ -9,7 +9,13 @@ properties:
     type: object
     additionalProperties: false
     properties:
-      livetime: {type: number, unit: hour} # ToDo: create list of livetimes for several observations later
+      livetime: {type: number, unit: hour}
+      zenith: {type: number, unit: deg, description: Mean zenith angle}
+      offset: {type: number, unit: deg, description: Mean offset angle}
+      n_on: {type: number, unit: counts}
+      n_off: {type: number, unit: counts}
+      alpha: {type: number, unit: none}
+      excess: {type: number, unit: counts}
       significance: {type: number, unit: none}
 
   pos:
@@ -19,31 +25,43 @@ properties:
       ra:
         type: object
         additionalProperties: false
-        description: Right Ascension in deg
+        description: |
+          Right Ascension (ICRC or FK5 J2000, it's almost the same)
+          Number in deg or string that can be parsed by Angle
         properties:
           val: {type: [number, string]}
           err: {type: [number, string], description: Statistical error}
+          err_sys: {type: [number, string], description: Systematic error}
       dec:
         type: object
         additionalProperties: false
-        description: Declination in deg
+        description: |
+          Declination (ICRC or FK5 J2000, it's almost the same)
+          Number in deg or string that can be parsed by Angle
         properties:
           val: {type: [number, string]}
           err: {type: [number, string], description: Statistical error}
+          err_sys: {type: [number, string], description: Systematic error}
       glon:
         type: object
         additionalProperties: false
-        description: Galactic longitude # in deg?
+        description: |
+          Galactic longitude
+          Number in deg or string that can be parsed by Angle
         properties:
           val: {type: [number, string]}
           err: {type: [number, string], description: Statistical error}
+          err_sys: {type: [number, string], description: Systematic error}
       glat:
         type: object
         additionalProperties: false
-        description: Galactic latitude # in deg?
+        description: |
+          Galactic latitude
+          Number in deg or string that can be parsed by Angle
         properties:
           val: {type: [number, string]}
           err: {type: [number, string], description: Statistical error}
+          err_sys: {type: [number, string], description: Systematic error}
 
   morph:
     type: object
@@ -55,7 +73,7 @@ properties:
         additionalProperties: false
         description: |
           Width parameter (semantics type-dependent)
-          Must parse as angle quantity.
+          Number in deg or string that can be parsed by Angle
         properties:
           val: {type: [string, number]}
           err: {type: [string, number], description: Statistical error}
@@ -64,15 +82,17 @@ properties:
         additionalProperties: false
         description: |
           Width parameter (semantics type-dependent)
-          Must parse as angle quantity.
+          Number in deg or string that can be parsed by Angle
         properties:
           val: {type: [string, number]}
           err: {type: [string, number], description: Statistical error}
-      pa: # redundant to pos, see line 15?
+      pa:
         type: object
         additionalProperties: false
         unit: deg
-        description: Position angle
+        description: |
+          Position angle
+          Number in deg or string that can be parsed by Angle
         properties:
           frame: {enum: [radec, galactic]}
           val: {type: number}


### PR DESCRIPTION
We should add the data for HESS, W49B, 2016arXiv160900600H
http://adsabs.harvard.edu/abs/2016arXiv160900600H

Spectral points from Francois Brun via email Nov 4, 2016:
https://gist.github.com/cdeil/48dcae6fa8bcf832c4328520a991539f

> The csv file has 6 columns :
Energy, Energy_errorlow, Energy_errorhigh, differential flux (df), df_errorlow, df_errorhigh

> The differential flux is given in cm-2.s-1.TeV-1 and the errors on the flux are statistical only.
The last point has an error of 0, this is an UL at 95% CL.

> P.S. : In the figures of the paper, systematic error of 20% of the flux value has been added in quadrature to the statistical error of each point.

