### PR TITLE
Add HESS Vela Junior 2016arXiv161101863H

### DIFF
--- a/input/papers/2016/2016arXiv161101863H/tev-000039.ecsv
+++ b/input/papers/2016/2016arXiv161101863H/tev-000039.ecsv
@@ -1,0 +1,25 @@
+# %ECSV 0.9
+# ---
+# datatype:
+# - {name: e_ref, datatype: float32}
+# - {name: dnde, datatype: float32}
+# - {name: dnde_errp, datatype: float32}
+# - {name: dnde_errn, datatype: float32}
+# meta: !!omap
+# - source_id: 39
+# - paper_id: 2016arXiv161101863H
+# - comments: |
+#     Data from Manuel Paz Arribas via email on Oct 21, 2016
+e_ref dnde dnde_errp dnde_errn
+  0.4074      1.228e-10            2.77e-11           2.769e-11
+  0.5705      8.321e-11           7.618e-12           7.614e-12
+  0.8264      3.853e-11           3.081e-12           3.078e-12
+   1.211      1.847e-11           1.352e-12            1.35e-12
+   1.775      9.062e-12           6.253e-13           6.236e-13
+   2.598       4.05e-12           3.091e-13            3.08e-13
+   3.796      1.498e-12            1.47e-13           1.464e-13
+   5.547       5.69e-13           6.529e-14           6.466e-14
+   8.125      2.374e-13           3.262e-14           3.216e-14
+   11.86      6.469e-14           1.536e-14           1.514e-14
+   17.26      1.348e-14            6.93e-15           6.845e-15
+   24.99      3.329e-15           2.738e-15           2.686e-15

--- a/input/papers/2016/2016arXiv161101863H/tev-000039.yaml
+++ b/input/papers/2016/2016arXiv161101863H/tev-000039.yaml
@@ -1,0 +1,26 @@
+paper_id: 2016arXiv161101863H
+source_id: 39
+
+data:
+  livetime: 93.6
+  significance: 39.1
+
+# No source morphology fit published in this paper.
+# The shell outer radius of 1.0 is mentioned in the text.
+morph:
+  type: shell
+  sigma2: {val: 1.0}
+
+spec:
+  # This is the total spectrum.
+  # The paper also contains several sub-region spectral measurements.
+  type: ecpl
+  norm: {val: 32.163, err: 1.4643}
+  index: {val: 1.8118, err: 0.0816}
+  ecut: {val: 6.68003, err: 1.23605}
+  ref: 1
+  covar: [[2.1443e-24, -3.7242e-14, 2.4071e-14], [-3.7242e-14, 0.0066546, -0.0019996], [2.4071e-14, -0.0019996, 0.00076532]]
+
+  theta: 1.0
+  erange: {min: 0.316, max: 30}
+

--- a/input/schemas/paper_source_info.schema.yaml
+++ b/input/schemas/paper_source_info.schema.yaml
@@ -145,6 +145,12 @@ properties:
           val: {type: number}
           err: {type: number, description: Statistical error}
           err_sys: {type: number, description: Systematic error}
+      covar:
+        type: array
+        description: |
+          Covariance matrix
+          TODO: decide on format.
+          An example of a published covariance matrix is here: 2016arXiv161101863H
 
   notes: {type: string}
 


### PR DESCRIPTION
We should add the new Vela Junior paper info:
http://adsabs.harvard.edu/abs/2016arXiv161101863H

Spectral points and parameters from Manuel Paz Arribas via email on Oct 21, 2016 are here:
https://gist.github.com/cdeil/911a5f2d7f41fbe224d4783a5eb47a55