### PR TITLE
add input data for source_id 120

### DIFF
--- a/input/data/2011/2011ICRC....7..244S/tev-000120-sed.ecsv
+++ b/input/data/2011/2011ICRC....7..244S/tev-000120-sed.ecsv
@@ -1,0 +1,30 @@
+# %ECSV 0.9
+# ---
+# datatype:
+# - {name: e_ref, datatype: float32}
+# - {name: dnde, datatype: float32}
+# - {name: e_min, datatype: float32}
+# - {name: e_max, datatype: float32}
+# - {name: dnde_err, datatype: float32}
+
+# meta: !!omap
+# - data_type: sed
+# - source_id: 120
+# - reference_id: 2011ICRC....7..244S
+# - comments: |
+#     Spectral points for HESS J1831-098 from Figure 2.
+#     Data obtained via email by Arache Djannati-Atai on Nov 25, 2016.
+
+e_ref dnde e_min e_max dnde_err
+ 0.3025 6.9421176e-12  0.2397  0.4217 3.8934139e-12
+ 0.5322 5.2222529e-12  0.4217  0.7421  9.627803e-13
+ 0.9364 1.1336782e-12  0.7421  1.3057  2.812788e-13
+ 1.6477  5.016757e-13  1.3057  2.2976   9.18719e-14
+ 2.8993  1.063420e-13  2.2976  4.0428   2.98748e-14
+ 5.1016   5.65447e-14  4.0428  7.1138    9.7324e-15
+ 8.9769   1.06612e-14  7.1138 12.5175    3.5570e-15
+15.7959    1.6602e-15 12.5175 22.0259    1.3130e-15
+27.7945     5.087e-16 22.0259 38.7569     5.329e-16
+
+# TODO: add data for Residual and errResidual?
+# https://gist.github.com/cdeil/4f38143712a452aeef859afe859d85e2

--- a/input/data/2011/2011ICRC....7..244S/tev-000120.yaml
+++ b/input/data/2011/2011ICRC....7..244S/tev-000120.yaml
@@ -1,0 +1,4 @@
+source_id: 120
+reference_id: 2011ICRC....7..244S
+
+# TODO: add data


### PR DESCRIPTION
Input data has been added for HESS J1831-098. I filled the .ecsv file with spectral data, but I skipped data under the `Residual` and `errResidual` columns. The .yaml file is empty right now.

@cdeil - You're going to review this PR before merging. Does everything look alright?