### PR TITLE
Always put unit for angular extensions

### DIFF
--- a/input/data/2005/2005A%26A...432L..25A/tev-000110.yaml
+++ b/input/data/2005/2005A%26A...432L..25A/tev-000110.yaml
@@ -6,8 +6,8 @@ data:
   significance: 13
 
 pos:
-  glon: {val: 0.872 deg, err: 0.005 deg}
-  glat: {val: 0.076 deg, err: 0.005 deg}
+  glon: {val: 0.872d, err: 0.005d}
+  glat: {val: 0.076d, err: 0.005d}
 
 morph:
   type: point
@@ -15,10 +15,8 @@ morph:
 
 spec:
   type: pl2
-
   norm: {val: 5.7, err: 0.7, err_sys: 1.2}
   index: {val: 2.40, err: 0.11, err_sys: 0.20}
   ref: 0.2
-
-  theta: 0.1
+  theta: 0.1d
   erange: {min: 0.17}

--- a/input/data/2005/2005A%26A...435L..17A/tev-000079.yaml
+++ b/input/data/2005/2005A%26A...435L..17A/tev-000079.yaml
@@ -6,22 +6,20 @@ data:
   significance: 25
 
 pos:
-  ra: {val: 15h14m7s, err: 0h0m21s, err_sys: 0d0m20s}
-  dec: {val: -59d9m27s, err: 0d0m11s, err_sys: 0d0m20s}
+  ra: {val: 15h14m7s, err: 0h0m21s, err_sys: 20s}
+  dec: {val: -59d9m27s, err: 11s, err_sys: 20s}
 
 morph:
   type: gauss
-
   sigma: {val: 6.4m, err: 0.7m}
   sigma2: {val: 2.3m, err: 0.5m}
   # TODO: check `pa` orientation. Paper just says "wrt RA axis"
-  pa: {val: 41d, err: 13d}
+  pa: {frame: radec, val: 41d, err: 13d}
 
 spec:
   type: pl
-
   norm: {val: 5.7, err: 0.2, err_sys: 1.4}
   index: {val: 2.27, err: 0.03, err_sys: 0.20}
   erange: {min: 0.280, max: 40}
-  theta: 0.3
+  theta: 0.3d
   ref: 1

--- a/input/data/2005/2005A%26A...435L..17A/tev-000079.yaml
+++ b/input/data/2005/2005A%26A...435L..17A/tev-000079.yaml
@@ -12,10 +12,10 @@ pos:
 morph:
   type: gauss
 
-  sigma: {val: 6.4, err: 0.7}
-  sigma2: {val: 2.3, err: 0.5}
+  sigma: {val: 6.4m, err: 0.7m}
+  sigma2: {val: 2.3m, err: 0.5m}
   # TODO: check `pa` orientation. Paper just says "wrt RA axis"
-  pa: {val: 41, err: 13}
+  pa: {val: 41d, err: 13d}
 
 spec:
   type: pl
@@ -25,4 +25,3 @@ spec:
   erange: {min: 0.280, max: 40}
   theta: 0.3
   ref: 1
-

--- a/input/data/2005/2005A%26A...437L...7A/tev-000039.yaml
+++ b/input/data/2005/2005A%26A...437L...7A/tev-000039.yaml
@@ -11,7 +11,6 @@ morph:
 
 spec:
   type: pl
-
   norm: {val: 21, err: 2, err_sys: 6}
   index: {val: 2.1, err: 0.1, err_sys: 0.2}
   erange: {min: 0.5, max: 15}

--- a/input/data/2005/2005A%26A...439.1013A/tev-000061.yaml
+++ b/input/data/2005/2005A%26A...439.1013A/tev-000061.yaml
@@ -7,18 +7,16 @@ data:
   significance: 21
 
 pos:
-  ra: {val: 13h3m0.4s, err: 0h0m4.4s, err_sys: 0d0m20s}
-  dec: {val: -63d11m55s, err: 0d0m31s, err_sys: 0d0m20s}
+  ra: {val: 13h3m0.4s, err: 0h0m4.4s, err_sys: 20s}
+  dec: {val: -63d11m55s, err: 31s, err_sys: 20s}
 
 morph:
   type: gauss
-
   sigma: {val: 0.16d, err: 0.02d}
-  #TODO: no pa given in the paper
+  # TODO: no pa given in the paper
 
 spec:
   type: pl
-
   norm: {val: 4.3, err: 0.3}
   index: {val: 2.44, err: 0.05, err_sys: 0.2}
   ref: 1

--- a/input/data/2005/2005A%26A...442....1A/tev-000060.yaml
+++ b/input/data/2005/2005A%26A...442....1A/tev-000060.yaml
@@ -7,7 +7,7 @@ data:
 
 pos:
   ra: {val: 13h2m49.3s, err: 0h0m2.3s}
-  dec: {val: -63d49m53s, err: 0d0m21.1s}
+  dec: {val: -63d49m53s, err: 21.1s}
 
 morph:
   type: point

--- a/input/data/2006/2006A%26A...448L..43A/tev-000037.yaml
+++ b/input/data/2006/2006A%26A...448L..43A/tev-000037.yaml
@@ -11,21 +11,18 @@ pos:
 
 morph: 
   type: gauss
-
-  sigma: {val: 0.48, err: 0.03}
-  sigma2: {val: 0.36, err: 0.03}
+  sigma: {val: 0.48d, err: 0.03d}
+  sigma2: {val: 0.36d, err: 0.03d}
   #TODO: check position angle (RADEC or GALACTIC orientation?)
-  
-  pa: {val: 41, err: 7}
+  pa: {val: 41d, err: 7d}
+
 spec:
   type: ecpl
-
-  #Spectrum not given in the paper
-  #Computed from the given integral flux above 1Tev of int_flux: {val: 1.28, err: 0.17, err_sys: 0.38} e-11 cm-2s-1
-  #The errors are approximated with 'norm_err/norm = int_flux_err / int_flux'
+  # Spectrum not given in the paper
+  # Computed from the given integral flux above 1Tev of int_flux: {val: 1.28, err: 0.17, err_sys: 0.38} e-11 cm-2s-1
+  # The errors are approximated with 'norm_err/norm = int_flux_err / int_flux'
   norm: {val: 10.2, err: 1.35, err_sys: 3.03}
   index: {val: 1.45, err: 0.09, err_sys: 0.2}
   ecut: {val: 13.8, err: 2.3, err_sys: 4.1}
-  
-  theta: 0.8
+  theta: 0.8d
   erange: {min: 0.550, max: 65}

--- a/input/data/2006/2006A%26A...456..245A/tev-000065.yaml
+++ b/input/data/2006/2006A%26A...456..245A/tev-000065.yaml
@@ -6,21 +6,19 @@ data:
   significance: 13.2
 
 pos:
-  ra: {val: 14h18m4s, err: 7s}
+  ra: {val: 14h18m4s, err: 0h0m7s}
   dec: {val: -60d58m31s, err: 35s}
 
 morph:
   type: gauss
   sigma: {val: 4.9m, err: 1.5m}
   sigma2: {val: 2.7m, err: 0.7m}
-  pa: {val: 46.2, err: 20.4, frame: radec}
+  pa: {frame: radec, val: 46.2d, err: 20.4d}
 
 spec:
   type: pl2
-
   norm: {val: 2.17, err: 0.17, err_sys: 0.43}
   index: {val: 2.22, err: 0.08, err_sys: 0.1}
   ref: 1
-
-  theta: 0.16
-  erange: {min: 0.3 , max: }
+  theta: 0.16d
+  erange: {min: 0.3}

--- a/input/data/2006/2006A%26A...456..245A/tev-000066.yaml
+++ b/input/data/2006/2006A%26A...456..245A/tev-000066.yaml
@@ -6,7 +6,7 @@ data:
   significance: 15.2
 
 pos:
-  ra: {val: 14h20m4s, err: 7s}
+  ra: {val: 14h20m9s, err: 0h0m4s}
   dec: {val: -60d45m36s, err: 32s}
 
 morph:
@@ -15,10 +15,8 @@ morph:
 
 spec:
   type: pl2
-
   norm: {val: 2.97, err: 0.18, err_sys: 0.6}
   index: {val: 2.17, err: 0.06, err_sys: 0.1}
   ref: 1
-
-  theta: 0.16
-  erange: {min: 0.3 , max: }
+  theta: 0.16d
+  erange: {min: 0.3}

--- a/input/data/2006/2006A%26A...457..899A/tev-000025.yaml
+++ b/input/data/2006/2006A%26A...457..899A/tev-000025.yaml
@@ -9,11 +9,9 @@ morph:
 
 spec:
   type: ecpl
-
   norm: {val: 37.6, err: 0.7}
   index: {val: 2.39, err: 0.03, err_sys: 0.09}
   ecut: {val: 14.3, err: 2.1}
   ref: 1
-
-  theta: 0.11
+  theta: 0.11d
   erange: {min: 0.44, max: 40.0}

--- a/input/data/2006/2006A%26A...460..365A/tev-000118.yaml
+++ b/input/data/2006/2006A%26A...460..365A/tev-000118.yaml
@@ -9,16 +9,15 @@ data:
   significance: 33.8
 
 pos:
-  ra: {val: 18h25m41s, err: 3s}
-  dec: {val: -13d50m21s, err: 35 arcsec}
+  ra: {val: 18h25m41s, err: 0h0m3s}
+  dec: {val: -13d50m21s, err: 35s}
 
 morph:
   type: gauss
-  sigma: {val: 0.24 deg, err: 0.02 deg}
+  sigma: {val: 0.24d, err: 0.02d}
 
 spec:
   type: ecpl
-
   # Results taken from Table 1 ecpl model
   # TODO: I'm not sure the norm is entered correctly!?
   #       Have to check ECPL parametrization exactly.
@@ -26,6 +25,5 @@ spec:
   index: {val: 2.26, err: 0.03}
   ecut: {val: 24.8, err: 7.2}
   ref: 1
-
-  theta: 0.8
+  theta: 0.8d
   erange: {min: 0.27}

--- a/input/data/2006/2006A%26A...460..743A/tev-000119.yaml
+++ b/input/data/2006/2006A%26A...460..743A/tev-000119.yaml
@@ -7,8 +7,8 @@ data:
   excess: 1960
 
 pos:
-  glon: {val: 16.879d, err: 0d0m12s, err_sys: 0d0m20s}
-  glat: {val: -1.285d, err: 0d0m12s, err_sys: 0d0m20s}
+  glon: {val: 16.879d, err: 12s, err_sys: 20s}
+  glat: {val: -1.285d, err: 12s, err_sys: 20s}
 
 morph:
   type: point
@@ -17,7 +17,6 @@ spec:
   # TODO: multiple spectra given for this binary, need to add the others.
   # The following spectrum is for <which one you like better>
   type: ecpl
-  
   norm: {val: 2.28, err: 0.10}
   index: {val: 1.85, err: 0.06}
   ecut: {val: 8.7, err: 2.0}

--- a/input/data/2006/2006ApJ...636..777A/tev-000083.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000083.yaml
@@ -6,21 +6,19 @@ data:
   significance: 10.1
 
 pos:
-  glon: {val: 331.52, err: 0.03}
-  glat: {val: -0.58, err: 0.02}
+  glon: {val: 331.52d, err: 0.03d}
+  glat: {val: -0.58d, err: 0.02d}
 
 morph:
   type: gauss
-  sigma: {val: 0.23, err: 0.02}
-  sigma2: {val: 0.15, err: 0.02}
-  pa: {val: 49, err: 10, frame: galactic}
+  sigma: {val: 0.23d, err: 0.02d}
+  sigma2: {val: 0.15d, err: 0.02d}
+  pa: {frame: galactic, val: 49d, err: 10d}
 
 spec:
   type: pl2
-
   norm: {val: 57.8, err: 7.7, err_sys: 0.3}
   index: {val: 2.46, err: 0.2, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.4
-  erange: {min: 0.2 , max: }
+  theta: 0.4d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000084.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000084.yaml
@@ -6,19 +6,17 @@ data:
   significance: 16.3
 
 pos:
-  glon: {val: 332.391, err: 0.014}
-  glat: {val: 0.138, err: 0.013}
+  glon: {val: 332.391d, err: 0.014d}
+  glat: {val: 0.138d, err: 0.013d}
 
 morph:
   type: gauss
-  sigma: {val: 0.136, err: 0.008}
+  sigma: {val: 0.136d, err: 0.008d}
 
 spec:
   type: pl2
-
   norm: {val: 43.3, err: 2.0, err_sys: 0.3}
   index: {val: 2.35, err: 0.06, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.26
-  erange: {min: 0.2 , max: }
+  theta: 0.26d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000086.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000086.yaml
@@ -6,21 +6,19 @@ data:
   significance: 4.5
 
 pos:
-  glon: {val: 336.38, err: 0.04}
-  glat: {val: 0.19, err: 0.03}
+  glon: {val: 336.38d, err: 0.04d}
+  glat: {val: 0.19d, err: 0.03d}
 
 morph:
   type: gauss
-  sigma: {val: 0.21, err: 0.05}
-  sigma2: {val: 0.06, err: 0.04}
-  pa: {val: 21, err: 13, frame: galactic}
+  sigma: {val: 0.21d, err: 0.05d}
+  sigma2: {val: 0.06d, err: 0.04d}
+  pa: {frame: galactic, val: 21d, err: 13d}
 
 spec:
   type: pl2
-
   norm: {val: 28.7, err: 5.3, err_sys: 0.3}
   index: {val: 2.12, err: 0.2, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.36
-  erange: {min: 0.2 , max: }
+  theta: 0.36d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000087.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000087.yaml
@@ -6,19 +6,17 @@ data:
   significance: 4.2
 
 pos:
-  glon: {val: 337.11, err: 0.05}
-  glat: {val: 0.22, err: 0.04}
+  glon: {val: 337.11d, err: 0.05d}
+  glat: {val: 0.22d, err: 0.04d}
 
 morph:
   type: gauss
-  sigma: {val: 0.11, err: 0.03}
+  sigma: {val: 0.11d, err: 0.03d}
 
 spec:
   type: pl2
-
   norm: {val: 13.4, err: 2.6, err_sys: 0.3}
   index: {val: 2.38, err: 0.27, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.23
-  erange: {min: 0.2 , max: }
+  theta: 0.23d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000088.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000088.yaml
@@ -6,19 +6,17 @@ data:
   significance: 13.6
 
 pos:
-  glon: {val: 338.316, err: 0.007}
-  glat: {val: -0.021, err: 0.007}
+  glon: {val: 338.316d, err: 0.007d}
+  glat: {val: -0.021d, err: 0.007d}
 
 morph:
   type: gauss
-  sigma: {val: 0.045, err: 0.009}
+  sigma: {val: 0.045d, err: 0.009d}
 
 spec:
   type: pl2
-
   norm: {val: 20.9, err: 2.2, err_sys: 0.3}
   index: {val: 2.42, err: 0.15, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.16
-  erange: {min: 0.2 , max: }
+  theta: 0.16d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000092.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000092.yaml
@@ -6,19 +6,17 @@ data:
   significance: 4.0
 
 pos:
-  glon: {val: 344.26, err: 0.04}
-  glat: {val: -0.22, err: 0.03}
+  glon: {val: 344.26d, err: 0.04d}
+  glat: {val: -0.22d, err: 0.03d}
 
 morph:
   type: gauss
-  sigma: {val: 0.08, err: 0.04}
+  sigma: {val: 0.08d, err: 0.04d}
 
 spec:
   type: pl2
-
   norm: {val: 15.9, err: 1.8, err_sys: 0.3}
   index: {val: 2.31, err: 0.15, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.2
-  erange: {min: 0.2 , max: }
+  theta: 0.2d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000093.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000093.yaml
@@ -6,19 +6,17 @@ data:
   significance: 6.8
 
 pos:
-  glon: {val: 345.672, err: 0.013}
-  glat: {val: 0.438, err: 0.01}
+  glon: {val: 345.672d, err: 0.013d}
+  glat: {val: 0.438d, err: 0.01d}
 
 morph:
   type: gauss
-  sigma: {val: 0.054, err: 0.012}
+  sigma: {val: 0.054d, err: 0.012d}
 
 spec:
   type: pl2
-
   norm: {val: 8.8, err: 0.7, err_sys: 0.3}
   index: {val: 2.34, err: 0.11, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.17
-  erange: {min: 0.2 , max: }
+  theta: 0.17d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000095.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000095.yaml
@@ -6,19 +6,17 @@ data:
   significance: 4.0
 
 pos:
-  glon: {val: 348.65, err: 0.03}
-  glat: {val: 0.38, err: 0.03}
+  glon: {val: 348.65d, err: 0.03d}
+  glat: {val: 0.38d, err: 0.03d}
 
 morph:
   type: gauss
-  sigma: {val: 0.06, err: 0.04}
+  sigma: {val: 0.06d, err: 0.04d}
 
 spec:
   type: pl2
-
   norm: {val: 4.2, err: 1.5, err_sys: 0.3}
   index: {val: 2.27, err: 0.48, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.17
-  erange: {min: 0.2 , max: }
+  theta: 0.17d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000108.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000108.yaml
@@ -6,21 +6,19 @@ data:
   significance: 4.0
 
 pos:
-  glon: {val: 358.71, err: 0.04}
-  glat: {val: -0.64, err: 0.05}
+  glon: {val: 358.71d, err: 0.04d}
+  glat: {val: -0.64d, err: 0.05d}
 
 morph:
   type: gauss
-  sigma: {val: 0.21, err: 0.06}
-  sigma2: {val: 0.09, err: 0.04}
-  pa: {val: 54, err: 7, frame: galactic}
+  sigma: {val: 0.21d, err: 0.06d}
+  sigma2: {val: 0.09d, err: 0.04d}
+  pa: {frame: galactic, val: 54d, err: 7d}
 
 spec:
   type: pl2
-
   norm: {val: 11.2, err: 4.0, err_sys: 0.3}
   index: {val: 1.82, err: 0.29, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.36
-  erange: {min: 0.2 , max: }
+  theta: 0.36d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000113.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000113.yaml
@@ -6,19 +6,17 @@ data:
   significance: 13.0
 
 pos:
-  glon: {val: 8.401, err: 0.016}
-  glat: {val: -0.033, err: 0.018}
+  glon: {val: 8.401d, err: 0.016d}
+  glat: {val: -0.033d, err: 0.018d}
 
 morph:
   type: gauss
-  sigma: {val: 0.2, err: 0.01}
+  sigma: {val: 0.2d, err: 0.01d}
 
 spec:
   type: pl2
-
   norm: {val: 53.2, err: 2.0, err_sys: 0.3}
   index: {val: 2.72, err: 0.06, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.36
-  erange: {min: 0.2 , max: }
+  theta: 0.36d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000116.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000116.yaml
@@ -6,19 +6,17 @@ data:
   significance: 13.5
 
 pos:
-  glon: {val: 12.813, err: 0.005}
-  glat: {val: -0.0342, err: 0.005}
+  glon: {val: 12.813d, err: 0.005d}
+  glat: {val: -0.0342d, err: 0.005d}
 
 morph:
   type: gauss
-  sigma: {val: 0.036, err: 0.006}
+  sigma: {val: 0.036d, err: 0.006d}
 
 spec:
   type: pl2
-
   norm: {val: 14.2, err: 1.1, err_sys: 0.3}
   index: {val: 2.09, err: 0.08, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.15
-  erange: {min: 0.2 , max: }
+  theta: 0.15d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000118.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000118.yaml
@@ -6,19 +6,17 @@ data:
   significance: 8.4
 
 pos:
-  glon: {val: 17.82, err: 0.03}
-  glat: {val: -0.74, err: 0.03}
+  glon: {val: 17.82d, err: 0.03d}
+  glat: {val: -0.74d, err: 0.03d}
 
 morph:
   type: gauss
-  sigma: {val: 0.16, err: 0.02}
+  sigma: {val: 0.16d, err: 0.02d}
 
 spec:
   type: pl2
-
   norm: {val: 39.4, err: 2.2, err_sys: 0.3}
   index: {val: 2.46, err: 0.08, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.30
-  erange: {min: 0.2 , max: }
+  theta: 0.30d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000123.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000123.yaml
@@ -6,19 +6,17 @@ data:
   significance: 8.1
 
 pos:
-  glon: {val: 23.24, err: 0.02}
-  glat: {val: -0.32, err: 0.02}
+  glon: {val: 23.24d, err: 0.02d}
+  glat: {val: -0.32d, err: 0.02d}
 
 morph:
   type: gauss
-  sigma: {val: 0.09, err: 0.02}
+  sigma: {val: 0.09d, err: 0.02d}
 
 spec:
   type: pl2
-
   norm: {val: 18.7, err: 1.0, err_sys: 0.3}
   index: {val: 2.45, err: 0.16, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.20
-  erange: {min: 0.2 , max: }
+  theta: 0.20d
+  erange: {min: 0.2}

--- a/input/data/2006/2006ApJ...636..777A/tev-000124.yaml
+++ b/input/data/2006/2006ApJ...636..777A/tev-000124.yaml
@@ -6,21 +6,19 @@ data:
   significance: 12.2
 
 pos:
-  glon: {val: 25.185, err: 0.012}
-  glat: {val: -0.106, err: 0.016}
+  glon: {val: 25.185d, err: 0.012d}
+  glat: {val: -0.106d, err: 0.016d}
 
 morph:
   type: gauss
-  sigma: {val: 0.12, err: 0.02}
-  sigma2: {val: 0.05, err: 0.02}
-  pa: {val: 149, err: 10, frame: galactic}
+  sigma: {val: 0.12d, err: 0.02d}
+  sigma2: {val: 0.05d, err: 0.02d}
+  pa: {frame: galactic, val: 149d, err: 10d}
 
 spec:
   type: pl2
-
   norm: {val: 30.4, err: 1.6, err_sys: 0.3}
   index: {val: 2.27, err: 0.06, err_sys: 0.2}
   ref: 0.2
-
-  theta: 0.23
-  erange: {min: 0.2 , max: }
+  theta: 0.23d
+  erange: {min: 0.2}

--- a/input/data/2006/2006PhRvL..97v1102A/tev-000106.yaml
+++ b/input/data/2006/2006PhRvL..97v1102A/tev-000106.yaml
@@ -8,16 +8,14 @@ data:
 
 pos:
   ra: {val: 17h45m39.44s, err: 0h0m0.6s}
-  dec: {val: -29d0m30.3s, err: 0d0m9.7s}
+  dec: {val: -29d0m30.3s, err: 9.7s}
 
 morph:
   type: point
 
 spec:
   type: pl2
-
   norm: {val: 1.87, err: 0.10, err_sys: 0.30}
   index: {val: 2.25, err: 0.04, err_sys: 0.10}
   ref: 1
   erange: {min: 0.160,  max: 30}
-

--- a/input/data/2007/2007A%26A...469L...1A/tev-000030.yaml
+++ b/input/data/2007/2007A%26A...469L...1A/tev-000030.yaml
@@ -5,18 +5,16 @@ data:
   livetime: 13.5
 
 pos:
-  ra: {val: 6h32m58s, err: 1.8 arcmin}
-  dec: {val: 5d48m20s, err: 28 arcmin}
+  ra: {val: 6h32m58s, err: 1.8m}
+  dec: {val: 5d48m20s, err: 28m}
 
 morph:
   type: point
 
 spec:
   type: pl
-
   norm: {val: 0.91, err: 0.17, err_sys: 0.3}
   index: {val: 2.53, err: 0.26, err_sys: 0.2}
   ref: 1
-
-  theta: 0.11
+  theta: 0.11d
   erange: {min: 0.4}

--- a/input/data/2007/2007A%26A...472..489A/tev-000099.yaml
+++ b/input/data/2007/2007A%26A...472..489A/tev-000099.yaml
@@ -6,22 +6,20 @@ data:
   significance: 6.2
 
 pos:
-  ra: {val: 17h18m7s, err: 5s}
-  dec: {val: -38d33m, err: 2m}
+  ra: {val: 17h18m7s, err: 0h0m5s, err_sys: 20s}
+  dec: {val: -38d33m, err: 2m, err_sys: 20s}
 
 morph:
   type: gauss
   sigma: {val: 9m, err: 2m}
   sigma2: {val: 4m, err: 1m}
-  pa: {val: 33, err: 0, frame: radec}
+  pa: {frame: radec, val: 33d}
 
 spec:
   type: ecpl
-
   norm: {val: 0.3, err: 0.19, err_sys: 0.09}
   index: {val: 0.7, err: 0.6, err_sys: 0.2}
   ref: 1
   ecut: {val: 6, err: 3, err_sys: 1}
-
-  theta: 0.2
-  erange: {min: 0.45 , max: }
+  theta: 0.2d
+  erange: {min: 0.45}

--- a/input/data/2007/2007A%26A...472..489A/tev-000115.yaml
+++ b/input/data/2007/2007A%26A...472..489A/tev-000115.yaml
@@ -6,21 +6,19 @@ data:
   significance: 4.7
 
 pos:
-  ra: {val: 18h10m31s, err: 12s}
+  ra: {val: 18h10m31s, err: 0h0m12s}
   dec: {val: -19d18m, err: 2m}
 
 morph:
   type: gauss
   sigma: {val: 32m, err: 4m}
   sigma2: {val: 15m, err: 2m}
-  pa: {val: 50, err: 0, frame: radec}
+  pa: {frame: radec, val: 50d}
 
 spec:
   type: pl
-
   norm: {val: 4.6, err: 0.6, err_sys: 1.4}
   index: {val: 2.2, err: 0.1, err_sys: 0.2}
   ref: 1
-
-  theta: 0.5
-  erange: {min: 0.25 , max: }
+  theta: 0.5d
+  erange: {min: 0.25}

--- a/input/data/2007/2007ApJ...661..236A/tev-000039.yaml
+++ b/input/data/2007/2007ApJ...661..236A/tev-000039.yaml
@@ -6,13 +6,11 @@ data:
 
 morph:
   type: shell
-  sigma: {val: 60 arcmin}
+  sigma: {val: 60m}
 
 spec:
   type: pl
-
   norm: {val: 19.0, err: 0.8, err_sys: 4.0}
   index: {val: 2.24, err: 0.04, err_sys: 0.15}
-
-  theta: 1.0
+  theta: 1.0d
   erange: {min: 0.3, max: 20.0}

--- a/input/data/2008/2008A%26A...477..353A/tev-000068.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000068.yaml
@@ -6,20 +6,19 @@ data:
   significance: 7.3
 
 pos:
-  glon: {val: 314.409, err: 0.05}
-  glat: {val: -0.145, err: 0.05}
+  glon: {val: 314.409d, err: 0.05d}
+  glat: {val: -0.145d, err: 0.05d}
 
 morph:
   type: gauss
-  sigma: {val: 0.04, err: 0.02}
-  sigma2: {val: 0.08, err: 0.02}
-  pa: {val: 80, err: 17, frame: radec}
+  sigma: {val: 0.04d, err: 0.02d}
+  sigma2: {val: 0.08d, err: 0.02d}
+  pa: {frame: radec, val: 80d, err: 17d}
 
 spec:
   type: pl
   norm: {val: 1.3, err: 0.4, err_sys: 0.2}
   index: {val: 2.16, err: 0.14, err_sys: 0.2}
   ref: 1
-
-  theta: 0.2
+  theta: 0.2d
   erange: {min: 0.97 , max: 50}

--- a/input/data/2008/2008A%26A...477..353A/tev-000085.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000085.yaml
@@ -6,20 +6,19 @@ data:
   significance: 7.5
 
 pos:
-  glon: {val: 334.772, err: 0.05}
-  glat: {val: 0.045, err: 0.05}
+  glon: {val: 334.772d, err: 0.05d}
+  glat: {val: 0.045d, err: 0.05d}
 
 morph:
   type: gauss
-  sigma: {val: 0.07, err: 0.02}
-  sigma2: {val: 0.10, err: 0.05}
-  pa: {val: 3, err: 40, frame: radec}
+  sigma: {val: 0.07d, err: 0.02d}
+  sigma2: {val: 0.10d, err: 0.05d}
+  pa: {frame: radec, val: 3d, err: 40d}
 
 spec:
   type: pl
   norm: {val: 4.9, err: 0.9, err_sys: 0.2}
   index: {val: 2.18, err: 0.12, err_sys: 0.2}
   ref: 1
-
-  theta: 0.5
+  theta: 0.5d
   erange: {min: 0.6 , max: 50}

--- a/input/data/2008/2008A%26A...477..353A/tev-000092.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000092.yaml
@@ -6,20 +6,19 @@ data:
   significance: 12.8
 
 pos:
-  glon: {val: 344.304, err: 0.05}
-  glat: {val: -0.184, err: 0.05}
+  glon: {val: 344.304d, err: 0.05d}
+  glat: {val: -0.184d, err: 0.05d}
 
 morph:
   type: gauss
-  sigma: {val: 0.30, err: 0.02}
-  sigma2: {val: 0.15, err: 0.02}
-  pa: {val: 68, err: 7, frame: radec}
+  sigma: {val: 0.30d, err: 0.02d}
+  sigma2: {val: 0.15d, err: 0.02d}
+  pa: {frame: radec, val: 68d, err: 7d}
 
 spec:
   type: pl
   norm: {val: 9.1, err: 1.1, err_sys: 0.2}
   index: {val: 2.07, err: 0.08, err_sys: 0.2}
   ref: 1
-
-  theta: 0.6
+  theta: 0.6d
   erange: {min: 0.50 , max: 50}

--- a/input/data/2008/2008A%26A...477..353A/tev-000093.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000093.yaml
@@ -6,20 +6,19 @@ data:
   significance: 10.7
 
 pos:
-  glon: {val: 345.683, err: 0.05}
-  glat: {val: -0.469, err: 0.05}
+  glon: {val: 345.683d, err: 0.05d}
+  glat: {val: -0.469d, err: 0.05d}
 
 morph:
   type: gauss
-  sigma: {val: 0.06, err: 0.02}
-  sigma2: {val: 0.08, err: 0.02}
-  pa: {val: -20, err: 23, frame: radec}
+  sigma: {val: 0.06d, err: 0.02d}
+  sigma2: {val: 0.08d, err: 0.02d}
+  pa: {frame: radec, val: -20d, err: 23d}
 
 spec:
   type: pl
   norm: {val: 2.7, err: 0.3, err_sys: 0.2}
   index: {val: 2.46, err: 0.08, err_sys: 0.2}
   ref: 1
-
-  theta: 0.3
+  theta: 0.3d
   erange: {min: 0.50 , max: 60}

--- a/input/data/2008/2008A%26A...477..353A/tev-000103.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000103.yaml
@@ -6,20 +6,19 @@ data:
   significance: 8.1
 
 pos:
-  glon: {val: 353.565, err: 0.05}
-  glat: {val: -0.622, err: 0.05}
+  glon: {val: 353.565d, err: 0.05d}
+  glat: {val: -0.622d, err: 0.05d}
 
 morph:
   type: gauss
-  sigma: {val: 0.18, err: 0.07}
-  sigma2: {val: 0.11, err: 0.03}
-  pa: {val: -89, err: 21, frame: radec}
+  sigma: {val: 0.18d, err: 0.07d}
+  sigma2: {val: 0.11d, err: 0.03d}
+  pa: {frame: radec, val: -89d, err: 21d}
 
 spec:
   type: pl
   norm: {val: 6.1, err: 0.8, err_sys: 0.2}
   index: {val: 2.26, err: 0.10, err_sys: 0.2}
   ref: 1
-
-  theta: 0.6
+  theta: 0.6d
   erange: {min: 0.50 , max: 80}

--- a/input/data/2008/2008A%26A...477..353A/tev-000125.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000125.yaml
@@ -6,20 +6,19 @@ data:
   significance: 10.6
 
 pos:
-  glon: {val: 26.795, err: 0.05}
-  glat: {val: -0.197, err: 0.05}
+  glon: {val: 26.795d, err: 0.05d}
+  glat: {val: -0.197d, err: 0.05d}
 
 morph:
   type: gauss
-  sigma: {val: 0.41, err: 0.04}
-  sigma2: {val: 0.25, err: 0.02}
-  pa: {val: 39, err: 6, frame: radec}
+  sigma: {val: 0.41d, err: 0.04d}
+  sigma2: {val: 0.25d, err: 0.02d}
+  pa: {frame: radec, val: 39d, err: 6d}
 
 spec:
   type: pl
   norm: {val: 12.8, err: 1.3, err_sys: 0.2}
   index: {val: 2.41, err: 0.08, err_sys: 0.2}
   ref: 1
-
-  theta: 0.7
+  theta: 0.7d
   erange: {min: 0.54 , max: 80}

--- a/input/data/2008/2008A%26A...477..353A/tev-000130.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000130.yaml
@@ -6,20 +6,19 @@ data:
   significance: 8.7
 
 pos:
-  glon: {val: 35.972, err: 0.05}
-  glat: {val: -0.056, err: 0.05}
+  glon: {val: 35.972d, err: 0.05d}
+  glat: {val: -0.056d, err: 0.05d}
 
 morph:
   type: gauss
-  sigma: {val: 0.11, err: 0.08}
-  sigma2: {val: 0.08, err: 0.03}
-  pa: {val: -3, err: 49, frame: radec}
+  sigma: {val: 0.11d, err: 0.08d}
+  sigma2: {val: 0.08d, err: 0.03d}
+  pa: {frame: radec, val: -3d, err: 49d}
 
 spec:
   type: pl
   norm: {val: 6.1, err: 0.7, err_sys: 0.2}
   index: {val: 2.39, err: 0.08, err_sys: 0.2}
   ref: 1
-
-  theta: 0.46
+  theta: 0.46d
   erange: {min: 0.60 , max: 80}

--- a/input/data/2008/2008A%26A...477..353A/tev-000131.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000131.yaml
@@ -6,20 +6,19 @@ data:
   significance: 7.0
 
 pos:
-  glon: {val: 35.578, err: 0.05}
-  glat: {val: -0.581, err: 0.05}
+  glon: {val: 35.578d, err: 0.05d}
+  glat: {val: -0.581d, err: 0.05d}
 
 morph:
   type: gauss
-  sigma: {val: 0.08, err: 0.02}
-  sigma2: {val: 0.02, err: 0.04}
-  pa: {val: 4, err: 17, frame: radec}
+  sigma: {val: 0.08d, err: 0.02d}
+  sigma2: {val: 0.02d, err: 0.04d}
+  pa: {frame: radec, val: 4d, err: 17d}
 
 spec:
   type: pl
   norm: {val: 0.6, err: 0.1, err_sys: 0.2}
   index: {val: 2.17, err: 0.12, err_sys: 0.2}
   ref: 1
-
-  theta: 0.15
+  theta: 0.15d
   erange: {min: 0.50 , max: 80}

--- a/input/data/2008/2008A%26A...481..401A/tev-000112.yaml
+++ b/input/data/2008/2008A%26A...481..401A/tev-000112.yaml
@@ -6,18 +6,17 @@ data:
   significance: 7.9
 
 pos:
-  ra: {val: 270.426, err: 0.031}
-  dec: {val: -23.335, err: 0.032}
+  ra: {val: 270.426d, err: 0.031d}
+  dec: {val: -23.335d, err: 0.032d}
 
 morph:
   type: gauss
-  sigma: {val: 0.17, err: 0.03}
+  sigma: {val: 0.17d, err: 0.03d}
 
 spec:
   type: pl
   norm: {val: 7.5, err: 1.11, err_sys: 0.3}
   index: {val: 2.66, err: 0.27, err_sys: 0.2}
   ref: 1
-
-  theta: 0.2
+  theta: 0.2d
   erange: {min: 0.3 , max: 5}

--- a/input/data/2008/2008A%26A...481..401A/tev-000156.yaml
+++ b/input/data/2008/2008A%26A...481..401A/tev-000156.yaml
@@ -6,18 +6,17 @@ data:
   significance: 7.8
 
 pos:
-  ra: {val: 270.110, err: 0.002}
-  dec: {val: -24.039, err: 0.009}
+  ra: {val: 270.110d, err: 0.002d}
+  dec: {val: -24.039d, err: 0.009d}
 
 morph:
   type: gauss
-  sigma: {val: 0.15}
+  sigma: {val: 0.15d}
 
 spec:
   type: pl
   norm: {val: 7.58, err: 0.90, err_sys: 0.15}
   index: {val: 2.50, err: 0.17, err_sys: 0.2}
   ref: 1
-
-  theta: 0.2
+  theta: 0.2d
   erange: {min: 0.3 , max: 5}

--- a/input/data/2008/2008A%26A...483..509A/tev-000108.yaml
+++ b/input/data/2008/2008A%26A...483..509A/tev-000108.yaml
@@ -18,10 +18,8 @@ morph:
 
 spec:
   type: pl
-
   norm: {val: 2.84, err: 0.23, err_sys: 0.28}
   index: {val: 2.71, err: 0.11, err_sys: 0.20}
   ref: 1
-
-  theta: 0.4
+  theta: 0.4d
   erange: {min: 0.15}

--- a/input/data/2008/2008A%26A...484..435A/tev-000134.yaml
+++ b/input/data/2008/2008A%26A...484..435A/tev-000134.yaml
@@ -7,19 +7,17 @@ data:
   significance: 7.5
 
 pos:
-  ra: {val: 19h12m49s, err: 3 arcmin}
-  dec: {val: +10d09m6s, err: 3 arcmin}
+  ra: {val: 19h12m49s, err: 3m}
+  dec: {val: +10d09m6s, err: 3m}
 
 morph:
   type: gauss
-  sigma: {val: 0.26 deg, err: 0.03 deg}
+  sigma: {val: 0.26d, err: 0.03d}
 
 spec:
   type: pl
-
   norm: {val: 3.5, err: 0.6, err_sys: 1.0}
   index: {val: 2.7, err: 0.2, err_sys: 0.3}
   ref: 1
-
-  theta: 0.5
+  theta: 0.5d
   erange: {min: 0.8}

--- a/input/data/2008/2008A%26A...486..829A/tev-000095.yaml
+++ b/input/data/2008/2008A%26A...486..829A/tev-000095.yaml
@@ -5,28 +5,25 @@ reference_id: 2008A&A...486..829A
 # CTB 37B = HESS J1713-381
 # CTB 37A = HESS J1714-385
 
-
 data:
   livetime: 55.4
   excess: 292
   significance: 8.6
 
 pos:
-  ra: {val: 17h13m54s, err: 4s, err_sys: 20 arcsec}
-  dec: {val: -38d11m58s, err: 45 arcsec, err_sys: 20 arcsec}
+  ra: {val: 17h13m54s, err: 0h0m4s, err_sys: 20s}
+  dec: {val: -38d11m58s, err: 45s, err_sys: 20s}
 
 morph:
   # Note: results obtained from double-Gauss source fit,
   # to take nearby source CTB 37A into account
   type: gauss
-  sigma: {val: 2.6 arcmin, err: 0.8 arcmin}
+  sigma: {val: 2.6m, err: 0.8m}
 
 spec:
   type: pl
-
   norm: {val: 0.65, err: 0.11, err_sys: 0.13}
   index: {val: 2.65, err: 0.19, err_sys: 0.20}
   ref: 1
-
-  theta: 0.187
+  theta: 0.187d
   erange: {min: 0.25}

--- a/input/data/2008/2008AIPC.1085..281R/tev-000075.yaml
+++ b/input/data/2008/2008AIPC.1085..281R/tev-000075.yaml
@@ -11,14 +11,12 @@ pos:
 
 morph:
   type: gauss
-  sigma: {val: 0.26}
+  sigma: {val: 0.26d}
 
 spec:
   type: pl
   norm: {val: 1.6, err: 0.6}
   index: {val: 2.4, err: 0.4, err_sys: 0.2}
   ref: 1
-
   erange: {min: 0.8}
-
-  theta: 0.4
+  theta: 0.4d

--- a/input/data/2008/2008AIPC.1085..285R/tev-000064.yaml
+++ b/input/data/2008/2008AIPC.1085..285R/tev-000064.yaml
@@ -6,18 +6,17 @@ data:
   significance: 8.5
 
 pos:
-  ra: {val: 13h56m00s, err: 2s}
-  dec: {val: -64d30m00s, err: 2s}
+  ra: {val: 13h56m}
+  dec: {val: -64d30m}
 
 morph:
   type: gauss
-  sigma: {val: 0.2, err: 0.02}
+  sigma: {val: 0.20d, err: 0.02d}
 
 spec:
   type: pl
   norm: {val: 3.5, err: 0.6}
   index: {val: 2.2, err: 0.2, err_sys: 0.2}
   ref: 1
-
-  theta: 0.22
+  theta: 0.22d
   erange: {min: 0.3, max: 30}

--- a/input/data/2008/2008AIPC.1085..372C/tev-000128.yaml
+++ b/input/data/2008/2008AIPC.1085..372C/tev-000128.yaml
@@ -6,18 +6,17 @@ data:
   significance: 9
 
 pos:
-  glon: {val: 31}
-  glat: {val: -0.16}
+  glon: {val: 31d}
+  glat: {val: -0.16d}
 
 morph:
   type: gauss
-  sigma: {val: 0.32, err: 0.02}
+  sigma: {val: 0.32d, err: 0.02d}
 
 spec:
   type: pl
   norm: {val: 3.7, err: 0.4, err_sys: 0.7}
   index: {val: 2.8, err: 0.2, err_sys: 0.2}
   ref: 1
-
-  theta: 0.2
+  theta: 0.2d
   erange: {min: 0.9, max: 12}

--- a/input/data/2009/2009A%26A...499..723A/tev-000132.yaml
+++ b/input/data/2009/2009A%26A...499..723A/tev-000132.yaml
@@ -2,24 +2,21 @@ source_id: 132
 reference_id: 2009A&A...499..723A
 
 data:
-
   livetime: 27
   significance: 12.1
   excess: 689
 
 pos:
-  glon: {val: 40d23m9.2s, err: 0d2.4m, err_sys: 0d20s}
-  glat: {val: -0d47m10.1s, err: 0d2.4m, err_sys: 0d20s}
+  glon: {val: 40d23m9.2s, err: 2.4m, err_sys: 20s}
+  glat: {val: -0d47m10.1s, err: 2.4m, err_sys: 20s}
 
 morph:
   type: gauss
-
-  # TODO: sigma and sigma2 have assymmetric errors: -0.03, +0.04, no 'pa' value found
+  # TODO: in the paper, an asymmetric error for `sigma` is given: -0.03, +0.04
   sigma: {val: 0.34d, err: 0.04d}
 
 spec:
   type: pl
-
   norm: {val: 4.14, err: 0.32, err_sys: 0.83}
   index: {val: 2.1, err: 0.07, err_sys: 0.2}
   ref: 1

--- a/input/data/2010/2010ApJ...719L..69A/tev-000136.yaml
+++ b/input/data/2010/2010ApJ...719L..69A/tev-000136.yaml
@@ -7,8 +7,8 @@ data:
   significance: 7.0
 
 pos:
-  ra: {val: 19h30m32s, err: 25s, err_sys: 0.02 deg}
-  dec: {val: +18d52m12s, err: 20s, err_sys: 0.02 deg}
+  ra: {val: 19h30m32s, err: 0h0m25s, err_sys: 0.02d}
+  dec: {val: +18d52m12s, err: 20s, err_sys: 0.02d}
 
 morph:
   type: gauss
@@ -16,10 +16,8 @@ morph:
 
 spec:
   type: pl
-
   norm: {val: 0.75, err: 0.12, err_sys: 0.15}
   index: {val: 2.39, err: 0.23, err_sys: 0.30}
   ref: 1
-
-  theta: 0.15
+  theta: 0.15d
   erange: {min: 0.25, max: 4}

--- a/input/data/2011/2011A%26A...525A..45H/tev-000077.yaml
+++ b/input/data/2011/2011A%26A...525A..45H/tev-000077.yaml
@@ -6,18 +6,17 @@ data:
   significance: 9.3
 
 pos:
-  ra: {val: 226.72, err: 0.05}
-  dec: {val: -62.35, err: 0.03}
+  ra: {val: 226.72d, err: 0.05d}
+  dec: {val: -62.35d, err: 0.03d}
 
 morph:
   type: gauss
-  sigma: {val: 0.15, err: 0.02}
+  sigma: {val: 0.15d, err: 0.02d}
 
 spec:
   type: pl
   norm: {val: 3.1, err: 0.8}
   index: {val: 2.49, err: 0.18, err_sys: 0.2}
   ref: 1
-
-  theta: 0.22
-  erange: {min: 0.5, max: }
+  theta: 0.22d
+  erange: {min: 0.5}

--- a/input/data/2011/2011A%26A...525A..46H/tev-000046.yaml
+++ b/input/data/2011/2011A%26A...525A..46H/tev-000046.yaml
@@ -6,18 +6,17 @@ data:
   significance: 16
 
 pos:
-  ra: {val: 10h23m24s, err: 7.2s}
-  dec: {val: -57d47m24s, err: 0h1m12s}
+  ra: {val: 10h23m24s, err: 0h0m7.2s}
+  dec: {val: -57d47m24s, err: 1m12s}
 
 morph:
   type: gauss
-  sigma: {val: 0.18, err: 0.02}
+  sigma: {val: 0.18d, err: 0.02d}
 
 spec:
   type: pl
   norm: {val: 3.25, err: 0.5, err_sys: 0.65}
   index: {val: 2.58, err: 0.19, err_sys: 0.2}
   ref: 1
-
-  theta: 0.33
-  erange: {min: 0.8 , max: }
+  theta: 0.33d
+  erange: {min: 0.8}

--- a/input/data/2011/2011A%26A...525A..46H/tev-000047.yaml
+++ b/input/data/2011/2011A%26A...525A..46H/tev-000047.yaml
@@ -6,17 +6,17 @@ data:
   significance: 7
 
 pos:
-  ra: {val: 10h26m38.4s, err: 21.6s}
-  dec: {val: -58d12m00s, err: 0h1m48s}
+  ra: {val: 10h26m38.4s, err: 0h0m21.6s, err_sys: 20s}
+  dec: {val: -58d12m00s, err: 1m48s, err_sys: 20s}
 
 morph:
   type: gauss
-  sigma: {val: 0.14, err: 0.03}
+  sigma: {val: 0.14d, err: 0.03d}
 
 spec:
   type: pl
   norm: {val: 0.99, err: 0.34, err_sys: 0.2}
   index: {val: 1.94, err: 0.2, err_sys: 0.2}
   ref: 1
-  theta: 0.33
-  erange: {min: 0.8 , max: }
+  theta: 0.33d
+  erange: {min: 0.8}

--- a/input/data/2011/2011A%26A...528A.143H/tev-000094.yaml
+++ b/input/data/2011/2011A%26A...528A.143H/tev-000094.yaml
@@ -6,18 +6,17 @@ data:
   significance: 7
 
 pos:
-  ra: {val: 17h08m11s, err: 17s}
-  dec: {val: -44d0m20s, err: 4s}
+  ra: {val: 17h08m11s, err: 0h0m17s}
+  dec: {val: -44d20m, err: 4m}
 
 morph:
   type: gauss
-  sigma: {val: 0.29, err: 0.04}
+  sigma: {val: 0.29d, err: 0.04d}
 
 spec:
   type: pl
   norm: {val: 4.2, err: 0.8, err_sys: 1.0}
   index: {val: 2.0, err: 0.1, err_sys: 0.2}
   ref: 1
-
-  theta: 0.71
-  erange: {min: 0.56 , max: }
+  theta: 0.71d
+  erange: {min: 0.56}

--- a/input/data/2011/2011A%26A...529A..49H/tev-000137.yaml
+++ b/input/data/2011/2011A%26A...529A..49H/tev-000137.yaml
@@ -22,6 +22,5 @@ spec:
   norm: {val: 0.56, err: 0.08, err_sys: 0.11}
   index: {val: 3.1, err: 0.3, err_sys: 0.2}
   ref: 1
-
-  theta: 0.1
+  theta: 0.1d
   erange: {min: 0.47}

--- a/input/data/2011/2011A%26A...531A..81H/tev-000102.yaml
+++ b/input/data/2011/2011A%26A...531A..81H/tev-000102.yaml
@@ -8,21 +8,18 @@ reference_id: 2011A&A...531A..81H
 pos:
   # Note: in the paper it's not clear if the position error value
   # is per axis or in total. We put it as per-axis here.
-  ra: {val: 17h29m35s, err: 0.035 deg}
-  dec: {val: -34d32m22s, err: 0.035 deg}
+  ra: {val: 17h29m35s, err: 0.035d}
+  dec: {val: -34d32m22s, err: 0.035d}
 
 morph:
   type: gauss
-
-  sigma: {val: 0.12, err: 0.03}
+  sigma: {val: 0.12d, err: 0.03d}
 
 # Values taken from Table 1
 spec:
   type: pl
-
   norm: {val: 0.44, err: 0.07} # TODO: add `err_sys_frac=0.2` once that's implemented
   index: {val: 2.24, err: 0.15, err_sys: 0.2}
   ref: 0.861
-
-  theta: 0.14
+  theta: 0.14d
   erange: {min: 0.24}

--- a/input/data/2011/2011A%26A...531A..81H/tev-000103.yaml
+++ b/input/data/2011/2011A%26A...531A..81H/tev-000103.yaml
@@ -11,16 +11,13 @@ pos:
 
 morph:
   type: shell
-
-  sigma: {val: 0.27, err: 0.02}
+  sigma: {val: 0.27d, err: 0.02d}
 
 # Values taken from Table 1
 spec:
   type: pl
-
   norm: {val: 4.67, err: 0.19} # TODO: add `err_sys_frac=0.2` once that's implemented
   index: {val: 2.32, err: 0.06, err_sys: 0.2}
   ref: 0.783
-
-  theta: 0.3
+  theta: 0.3d
   erange: {min: 0.24}

--- a/input/data/2011/2011A%26A...531L..18H/tev-000109.yaml
+++ b/input/data/2011/2011A%26A...531L..18H/tev-000109.yaml
@@ -7,20 +7,17 @@ data:
 
 pos:
   ra: {val: 17h47m49s, err: 0h1.8m, err_sys: 0h0m1.3s}
-  dec: {val: -24d48m30s, err: 0d0m36s, err_sys: 0d0m20s}
+  dec: {val: -24d48m30s, err: 36s, err_sys: 20s}
 
 morph:
   type: gauss
-
   sigma: {val: 9.6m, err: 2.4m}
   sigma2: {val: 1.8m, err: 1.2m}
   # TODO: in the paper it is mentioned "westwards from north", we need to decide which entry to use in gamma-cat
-  # frame: galactic
-  pa: {val: 92, err: 6}
+  pa: {frame: radec, val: 92d, err: 6d}
 
 spec:
   type: pl
-
   norm: {val: 0.52, err: 0.11}
   index: {val: 2.5, err: 0.3, err_sys: 0.2}
   ref: 1

--- a/input/data/2011/2011A%26A...533A.103H/tev-000064.yaml
+++ b/input/data/2011/2011A%26A...533A.103H/tev-000064.yaml
@@ -11,16 +11,12 @@ pos:
 
 morph:
   type: gauss
-
   sigma: {val: 0.20d, err: 0.02d}
 
 spec:
   type: pl
-  
-  #There is inconsistency in the paper: figure 2 says err_sys for norm: 1, text says 0.4
+  # There is inconsistency in the paper: figure 2 says err_sys for norm: 1, text says 0.4
   norm: {val: 2.7, err: 0.9, err_sys: 0.4}
   index: {val: 2.2, err: 0.2, err_sys: 0.2}
   ref: 1
-
   erange: {min: 1, max: 20}
-  

--- a/input/data/2011/2011ICRC....7..185A/tev-000081.yaml
+++ b/input/data/2011/2011ICRC....7..185A/tev-000081.yaml
@@ -16,9 +16,7 @@ morph:
 
 spec:
   type: pl
-
   norm: {val: 0.17, err: 0.03, err_sys: 0.04}
   index: {val: 2.1, err: 0.2, err_sys: 0.2}
   ref: 1.39
-
-  theta: 0.1
+  theta: 0.1d

--- a/input/data/2011/2011ICRC....7..244S/tev-000120.yaml
+++ b/input/data/2011/2011ICRC....7..244S/tev-000120.yaml
@@ -12,13 +12,11 @@ pos:
 
 morph:
   type: gauss
-  sigma: {val: 0.15 deg}
+  sigma: {val: 0.15d}
 
 spec:
   type: pl
-
   norm: {val: 1.1, err: 0.1}
   index: {val: 2.1, err: 0.1}
   ref: 1
-
-  theta: 0.3
+  theta: 0.3d

--- a/input/data/2012/2012A%26A...537A.114A/tev-000090.yaml
+++ b/input/data/2012/2012A%26A...537A.114A/tev-000090.yaml
@@ -7,8 +7,8 @@ data:
   excess: 2771
 
 pos:
-  ra: {val: 16h46m50s, err: 27s, }
-  dec: {val: -45d49m12s, err: 7m, }
+  ra: {val: 16h46m50s, err: 0h0m27s}
+  dec: {val: -45d49m12s, err: 7m}
 
 morph:
   type: gauss
@@ -19,11 +19,9 @@ morph:
 
 spec:
   type: pl
-
   norm: {val: 9.0, err: 1.4, err_sys: 1.8}
   index: {val: 2.19, err: 0.08, err_sys: 0.20}
   ref: 1
-
-  theta: 1.1
+  theta: 1.1d
   erange: {min: 0.45, max: 75}
 

--- a/input/data/2012/2012A%26A...541A...5H/tev-000044.yaml
+++ b/input/data/2012/2012A%26A...541A...5H/tev-000044.yaml
@@ -5,19 +5,17 @@ data:
   significance: 8.5
 
 pos:
-  ra: {val: 10h16m31s, err: 12s}
-  dec: {val: -58d58m48s, err: 3s}
+  ra: {val: 10h16m31s, err: 0h0m12s}
+  dec: {val: -58d58m48s, err: 3m}
 
 morph:
   type: gauss
-  sigma: {val: 0.15, err: 0.03}
+  sigma: {val: 0.15d, err: 0.03d}
 
 spec:
   type: pl
-
   norm: {val: 0.42, err: 0.11, err_sys: 0.08}
   index: {val: 2.9, err: 0.4, err_sys: 0.2}
   ref: 1
-
-  theta: 0.3
-  erange: {min: 0.6 , max: }
+  theta: 0.3d
+  erange: {min: 0.6}

--- a/input/data/2012/2012A%26A...541A...5H/tev-000045.yaml
+++ b/input/data/2012/2012A%26A...541A...5H/tev-000045.yaml
@@ -5,18 +5,16 @@ data:
   significance: 8.5
 
 pos:
-  ra: {val: 10h18m59.3s, err: 2.4s, }
-  dec: {val: -58d56m10s, err: 36s, }
+  ra: {val: 10h18m59.3s, err: 0h0m2.4s}
+  dec: {val: -58d56m10s, err: 36s}
 
 morph:
   type: point
 
 spec:
   type: pl
-
   norm: {val: 0.68, err: 0.16, err_sys: 0.13}
   index: {val: 2.7, err: 0.5, err_sys: 0.2}
   ref: 1
-
-  theta: 0.1
-  erange: {min: 0.6 , max: }
+  theta: 0.1d
+  erange: {min: 0.6}

--- a/input/data/2012/2012A%26A...545L...2H/tev-000027.yaml
+++ b/input/data/2012/2012A%26A...545L...2H/tev-000027.yaml
@@ -7,18 +7,16 @@ data:
   excess: 395
 
 pos:
-  ra: {val: 05h37m44.00s, err: 2 arcmin}
-  dec: {val: -69d09m57s, err: 11 arcmin}
+  ra: {val: 5h37m44s, err: 11s, err_sys: 20s}
+  dec: {val: -69d9m57s, err: 11s, err_sys: 20s}
 
 morph:
   type: point
 
 spec:
   type: pl
-
   norm: {val: 0.82, err: 0.08, err_sys: 0.25}
   index: {val: 2.8, err: 0.2, err_sys: 0.3}
   ref: 1
-
-  theta: 0.1
+  theta: 0.1d
   erange: {min: 0.6, max: 12.0}

--- a/input/data/2012/2012A%26A...548A..38A/tev-000037.yaml
+++ b/input/data/2012/2012A%26A...548A..38A/tev-000037.yaml
@@ -6,25 +6,22 @@ data:
   significance: 27.9
 
 pos:
-  ra: {val: 8h35m00s, err: 8s}
-  dec: {val: -45d36m00s, err: 120s}
+  ra: {val: 8h35m00s}
+  dec: {val: -45d36m00s}
 
 morph:
   type: gauss
-
-  sigma: {val: 28.8 arcmin, err: 1.8 arcmin}
-  sigma2: {val: 21.6 arcmin, err: 1.8 arcmin}
-  pa: {frame: radec, val: 41.0, err: 7.0}
+  sigma: {val: 28.8m, err: 1.8m}
+  sigma2: {val: 21.6m, err: 1.8m}
+  pa: {frame: radec, val: 41d, err: 7d}
 
 spec:
   type: ecpl
-
   norm: {val: 14.6, err: 0.8, err_sys: 3.0}
   index: {val: 1.32, err: 0.06, err_sys: 0.12}
   ecut: {val: 14.0, err: 1.6, err_sys: 2.6}
   ref: 1
-
-  theta: 1.2
+  theta: 1.2d
   erange: {min: 0.75}
 
 #  flux: {emin: 1.0, val: 21.0, err: 1.9, err_sys: 4.4}

--- a/input/data/2012/2012A%26A...548A..46H/tev-000061.yaml
+++ b/input/data/2012/2012A%26A...548A..46H/tev-000061.yaml
@@ -5,14 +5,14 @@ data:
   significance: 33
 
 pos:
-  ra: {val: 13h02m48s, err: 3s}
+  ra: {val: 13h02m48s, err: 0h0m3s}
   dec: {val: -63d10m39s, err: 24s}
 
 morph:
   type: gauss
-  sigma: {val: 0.194, err: 0.008}
-  sigma2: {val: 0.145, err: 0.006}
-  pa: {val: 147, err: 6, frame: radec}
+  sigma: {val: 0.194d, err: 0.008d}
+  sigma2: {val: 0.145d, err: 0.006d}
+  pa: {frame: radec, val: 147d, err: 6d}
 
 spec:
   type: ecpl
@@ -20,6 +20,5 @@ spec:
   index: {val: 1.5, err: 0.2, err_sys: 0.2}
   ecut: {val: 7.7, err: 2.2}
   ref: 1
-
-  theta: 0.6
-  erange: {min: 0.84 , max: }
+  theta: 0.6d
+  erange: {min: 0.84}

--- a/input/data/2013/2013ApJ...764...38A/tev-000001.yaml
+++ b/input/data/2013/2013ApJ...764...38A/tev-000001.yaml
@@ -6,21 +6,18 @@ data:
   significance: 7.5
 
 pos:
-  ra: {val: 0h6m26s, err: 0.09d, err_sys: 0d0m50s}
-  dec: {val: 72d59m01.0s, err: 0.04d, err_sys: 0d0m50s}
+  ra: {val: 0h6m26s, err: 0.09d, err_sys: 50s}
+  dec: {val: 72d59m01.0s, err: 0.04d, err_sys: 50s}
 
 morph:
   type: gauss
-
-  sigma: {val: 0.30, err: 0.03}
-  sigma2: {val: 0.24, err: 0.03}
-  # TODO: in the paper it is written 'west of north', hence, we think it is radec
-  # frame: radec
-  pa: {val: 17.4, err: 15.8}
+  sigma: {val: 0.30d, err: 0.03d}
+  sigma2: {val: 0.24d, err: 0.03d}
+  # TODO: pa is 'west of north' according to the paper
+  pa: {frame: radec, val: 17.4d, err: 15.8d}
 
 spec:
   type: pl
-
   norm: {val: 0.091, err: 0.013, err_sys: 0.017}
   index: {val: 2.2, err: 0.2, err_sys: 0.3}
   ref: 3

--- a/input/data/2013/2013arXiv1303.0979O/tev-000089.yaml
+++ b/input/data/2013/2013arXiv1303.0979O/tev-000089.yaml
@@ -6,8 +6,8 @@ data:
   significance: 8.6
 
 pos:
-  ra: {val: 16h41m1.7s, err: 3.1s}
-  dec: {val: -46d18m11s, err: 35s}
+  ra: {val: 16h41m1.7s, err: 0h0m3.1s, err_sys: 0h0m1.9s}
+  dec: {val: -46d18m11s, err: 35s, err_sys: 20s}
 
 morph:
   # parameters missing in the paper

--- a/input/data/2014/2014A%26A...562A..40H/tev-000117.yaml
+++ b/input/data/2014/2014A%26A...562A..40H/tev-000117.yaml
@@ -7,8 +7,8 @@ data:
   excess: 117
 
 pos:
-  ra: {val: 18h18m4.8s, err: 0h0m3.1s, err_sys: 0d0m20s}
-  dec: {val: -15d28m1s, err: 0d0m43s, err_sys: 0d0m20s}
+  ra: {val: 18h18m4.8s, err: 0h0m3.1s, err_sys: 20s}
+  dec: {val: -15d28m1s, err: 43s, err_sys: 20s}
 
 morph:
   type: gauss
@@ -16,10 +16,8 @@ morph:
 
 spec:
   type: pl
-
   norm: {val: 0.09, err: 0.02, err_sys: 0.02}
   index: {val: 2.3, err: 0.3, err_sys: 0.2}
   ref: 1.9
-  
   erange: {min: 0.42, max: 12.0}
 

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-1.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-1.yaml
@@ -4,7 +4,7 @@ reference_id: 2014ApJ...780..168A
 
 pos:
     # from fit to VERITAS data
-    ra: {val: 06h33m0.8s, err: 0.5s, err_sys: 50s }
+    ra: {val: 06h33m0.8s, err: 0h0m0.5s, err_sys: 50s }
     dec: {val: +5d47m39s, err: 10s, err_sys: 50s }
 
 morph:

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-2.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-2.yaml
@@ -4,7 +4,7 @@ reference_id: 2014ApJ...780..168A
 
 pos:
     # from fit to VERITAS data
-    ra: {val: 06h33m0.8s, err: 0.5s, err_sys: 50s }
+    ra: {val: 06h33m0.8s, err: 0h0m0.5s, err_sys: 50s }
     dec: {val: +5d47m39s, err: 10s, err_sys: 50s }
 
 morph:

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-3.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-3.yaml
@@ -4,7 +4,7 @@ reference_id: 2014ApJ...780..168A
 
 pos:
     # from fit to VERITAS data
-    ra: {val: 06h33m0.8s, err: 0.5s, err_sys: 50s }
+    ra: {val: 06h33m0.8s, err: 0h0m0.5s, err_sys: 50s }
     dec: {val: +5d47m39s, err: 10s, err_sys: 50s }
 
 morph:

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-4.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-4.yaml
@@ -4,7 +4,7 @@ reference_id: 2014ApJ...780..168A
 
 pos:
     # from fit to VERITAS data
-    ra: {val: 06h33m0.8s, err: 0.5s, err_sys: 50s }
+    ra: {val: 06h33m0.8s, err: 0h0m0.5s, err_sys: 50s }
     dec: {val: +5d47m39s, err: 10s, err_sys: 50s }
 
 morph:

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-5.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-5.yaml
@@ -4,7 +4,7 @@ reference_id: 2014ApJ...780..168A
 
 pos:
     # from fit to VERITAS data
-    ra: {val: 06h33m0.8s, err: 0.5s, err_sys: 50s }
+    ra: {val: 06h33m0.8s, err: 0h0m0.5s, err_sys: 50s }
     dec: {val: +5d47m39s, err: 10s, err_sys: 50s }
 
 morph:

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-6.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-6.yaml
@@ -4,7 +4,7 @@ reference_id: 2014ApJ...780..168A
 
 pos:
     # from fit to VERITAS data
-    ra: {val: 06h33m0.8s, err: 0.5s, err_sys: 50s }
+    ra: {val: 06h33m0.8s, err: 0h0m0.5s, err_sys: 50s }
     dec: {val: +5d47m39s, err: 10s, err_sys: 50s }
 
 morph:

--- a/input/data/2014/2014ApJ...794L...1A/tev-000089.yaml
+++ b/input/data/2014/2014ApJ...794L...1A/tev-000089.yaml
@@ -6,7 +6,7 @@ data:
   significance: 8.5
 
 pos:
-  ra: {val: 16h41m2.1s, err: 3.0s}
+  ra: {val: 16h41m2.1s, err: 0h0m3.0s}
   dec: {val: -46d18m13s, err: 35s}
 
 morph:
@@ -18,5 +18,4 @@ spec:
   norm: {val: 0.391, err: 0.069, err_sys: 0.078}
   index: {val: 2.07, err: 0.11, err_sys: 0.2}
   ref: 1
-
   erange: {min: 0.64, max: 100}

--- a/input/data/2014/2014MNRAS.439.2828A/tev-000088.yaml
+++ b/input/data/2014/2014MNRAS.439.2828A/tev-000088.yaml
@@ -6,7 +6,7 @@ data:
 
 pos:
   ra: {val: 16h40m41.0s, err: 0h0m1.0s, err_sys: 0h0m1.3s}
-  dec: {val: -46d32m31s, err: 0d0m14s, err_sys: 0d0m20s}
+  dec: {val: -46d32m31s, err: 14s, err_sys: 20s}
 
 morph:
   type: gauss
@@ -14,7 +14,6 @@ morph:
 
 spec: 
   type: ecpl
-
   norm: {val: 3.3, err: 0.1, err_sys: 0.6}
   index: {val: 2.11, err: 0.09, err_sys: 0.10}
   # TODO: Error on the cut-off energy is assymmetric: -1.2, +2.0

--- a/input/data/2015/2015A%26A...574A.100H/tev-000098.yaml
+++ b/input/data/2015/2015A%26A...574A.100H/tev-000098.yaml
@@ -6,7 +6,7 @@ data:
   significance: 6.6
 
 pos:
-  ra: {val: 17h17m57.8s, err: 2.0s, err_sys: 1.3s}
+  ra: {val: 17h17m57.8s, err: 0h0m2.0s, err_sys: 0h0m1.3s}
   dec: {val: -37d26m39.6s, err: 24.0s, err_sys: 20.0s}
 
 morph:
@@ -17,7 +17,5 @@ spec:
   norm: {val: 0.65, err: 0.11, err_sys: 0.13}
   index: {val: 2.8, err: 0.27, err_sys: 0.2}
   ref: 0.4
-
   erange: {min: 0.22}
-
-  theta: 0.1
+  theta: 0.1d

--- a/input/data/2015/2015A%26A...577A.131H/tev-000045.yaml
+++ b/input/data/2015/2015A%26A...577A.131H/tev-000045.yaml
@@ -6,15 +6,14 @@ data:
   significance: 9.3
 
 pos:
-  ra: {val: 10h18m58s, err: 0h0m5s, }
-  dec: {val: -58d56m43s, err: 0d0m30s, }
+  ra: {val: 10h18m58s, err: 0h0m5s}
+  dec: {val: -58d56m43s, err: 30s}
 
 morph:
   type: point
 
 spec:
   type: pl
-
   norm: {val: 0.29, err: 0.04, err_sys: 0.058}
   index: {val: 2.20, err: 0.14, err_sys: 0.2}
   ref: 1

--- a/input/data/2015/2015MNRAS.446.1163H/tev-000121.yaml
+++ b/input/data/2015/2015MNRAS.446.1163H/tev-000121.yaml
@@ -6,7 +6,7 @@ data:
 
 pos:
   ra: {val: 18h32m50s, err: 0h0m3s, err_sys: 0h0m2s}
-  dec: {val: -9d22m36s, err: 0d0m32s, err_sys: 0d0m20s}
+  dec: {val: -9d22m36s, err: 32s, err_sys: 20s}
 
 morph:
   type: gauss
@@ -15,9 +15,7 @@ morph:
 
 spec:
   type: pl
-
   norm: {val: 0.48, err: 0.08, err_sys: 0.1}
   index: {val: 2.6, err: 0.3, err_sys: 0.1}
   ref: 1
-
   erange: {min: 0.4, max: 5}

--- a/input/data/2016/2016Natur.531..476H/tev-000106.yaml
+++ b/input/data/2016/2016Natur.531..476H/tev-000106.yaml
@@ -6,8 +6,8 @@ data:
 
 # TODO: position taken from 2010MNRAS.402.1877A
 pos:
-  ra: {val: 17h45m39.6s , err: 0.4s}
-  dec: {val: -29d0m22s, err: 6 arcsec}
+  ra: {val: 17h45m39.6s , err: 0h0m0.4s}
+  dec: {val: -29d0m22s, err: 6s}
 
 # Note: No position or morphology fit is performed in this paper
 morph:
@@ -20,6 +20,5 @@ spec:
   ecut: {val: 10.7, err: 2.0, err_sys: 2.1}
   ref: 1
   # p-value(ECPL vs PL) = 3e-5 is quoted
-
-  theta: 0.1
+  theta: 0.1d
   # No energy threshold or range quoted, as far as I can see

--- a/input/data/2016/2016arXiv160104461H/tev-000070.yaml
+++ b/input/data/2016/2016arXiv160104461H/tev-000070.yaml
@@ -6,21 +6,19 @@ data:
 
 pos:
   # from shell fit
-  ra: {val: 14h42m53s, err: 9s}
-  dec: {val: -62d25m48s, err: 0h1m48s}
+  ra: {val: 14h42m53s, err: 0h0m7s}
+  dec: {val: -62d25m48s, err: 0d1m48s}
 
 morph:
   type: shell
-  sigma: {val: 0.19, err: 0.03} # inner radius
-  sigma2: {val: 0.30, err: 0.02} # outer radius
+  sigma: {val: 0.19d, err: 0.03d} # inner radius
+  sigma2: {val: 0.30d, err: 0.02d} # outer radius
 
 spec:
-  type: ecpl # more like 'ecpl', 'pl' because both were used in the paper and were transcripted here
-  # following data from tab 3 and fig 4
+  type: ecpl
   norm: {val: 3.0, err: 0.2, err_sys: 0.6}
   index: {val: 1.59, err: 0.22, err_sys: 0.2}
   ecut: {val: 3.47, err: 1.23}
   ref: 1
-
-  theta: 0.41 # see p.6 and fig 3, but 0.7 or 0.8 possible as well, see fig 2
-  erange: {min: 0.4, max: 50} # see p.8
+  theta: 0.41d
+  erange: {min: 0.4, max: 50}

--- a/input/data/2016/2016arXiv160900600H/tev-000133.yaml
+++ b/input/data/2016/2016arXiv160900600H/tev-000133.yaml
@@ -13,8 +13,8 @@ data:
 
 pos:
   # from two-source fit (point for W49B)
-  glon: {val: 43.260, err: 0.005, err_sys: 0.006}
-  glat: {val: -0.190, err: 0.005, err_sys: 0.006}
+  glon: {val: 43.260d, err: 0.005d, err_sys: 0.006d}
+  glat: {val: -0.190d, err: 0.005d, err_sys: 0.006d}
 
 morph:
   type: point
@@ -24,6 +24,5 @@ spec:
   norm: {val: 0.315, err: 0.046, err_sys: 0.063}
   index: {val: 3.14, err: 0.24, err_sys: 0.29}
   ref: 1
-
-  theta: 0.1
+  theta: 0.1d
   erange: {min: 0.29}

--- a/input/data/2016/2016arXiv160908671H/tev-000096.yaml
+++ b/input/data/2016/2016arXiv160908671H/tev-000096.yaml
@@ -5,21 +5,18 @@ data:
   livetime: 164
 
 pos:
-
-  ra: {val: '17h13m25.2s'}
-  dec: {val: '-39d46m15.6s'}
+  ra: {val: 17h13m25.2s}
+  dec: {val: -39d46m15.6s}
 
 morph:
   type: shell
-  sigma: {val: 0.5 deg}
+  sigma: {val: 0.5d}
 
 spec:
-  type: ecpl # more like 'ecpl', 'pl' because both were used in the paper and were transcripted here
-  # following data from tab 3 and fig 4
+  type: ecpl
   norm: {val: 20.2, err: 0.8}
   index: {val: 2.32, err: 0.02, err_sys: 0.1}
   ecut: {val: 12.9, err: 1.1}
   ref: 1
-
-  theta: 0.6 # see p.6 and fig 3, but 0.7 or 0.8 possible as well, see fig 2
-  erange: {min: 0.2, max: 40.0} # see p.8
+  theta: 0.6d
+  erange: {min: 0.2, max: 40.0}

--- a/input/data/2016/2016arXiv161005799S/tev-000137.yaml
+++ b/input/data/2016/2016arXiv161005799S/tev-000137.yaml
@@ -17,6 +17,4 @@ spec:
   norm: {val: 5.35, err: 0.44}
   index: {val: 2.8, err: 0.1}
   ref: 0.2
-
-#  theta: not given in the paper
   erange: {min: 0.2, max: 2.0}

--- a/input/data/2016/2016arXiv161101863H/tev-000039.yaml
+++ b/input/data/2016/2016arXiv161101863H/tev-000039.yaml
@@ -15,7 +15,7 @@ pos:
 # The shell outer radius of 1.0 is mentioned in the text.
 morph:
   type: shell
-  sigma: {val: 1.0}
+  sigma: {val: 1.0d}
 
 spec:
   # This is the total spectrum.
@@ -26,7 +26,5 @@ spec:
   ecut: {val: 6.68003, err: 1.23605}
   ref: 1
   covar: [[2.1443e-24, -3.7242e-14, 2.4071e-14], [-3.7242e-14, 0.0066546, -0.0019996], [2.4071e-14, -0.0019996, 0.00076532]]
-
-  theta: 1.0
+  theta: 1.0d
   erange: {min: 0.316, max: 30}
-

--- a/input/schemas/dataset_source_info.schema.yaml
+++ b/input/schemas/dataset_source_info.schema.yaml
@@ -73,30 +73,30 @@ properties:
         additionalProperties: false
         description: |
           Width parameter (semantics type-dependent)
-          Number in deg or string that can be parsed by Angle
+          String that can be parsed by Angle
         properties:
-          val: {type: [string, number]}
-          err: {type: [string, number], description: Statistical error}
+          val: {type: string}
+          err: {type: string, description: Statistical error}
       sigma2:
         type: object
         additionalProperties: false
         description: |
           Width parameter (semantics type-dependent)
-          Number in deg or string that can be parsed by Angle
+          String that can be parsed by Angle
         properties:
-          val: {type: [string, number]}
-          err: {type: [string, number], description: Statistical error}
+          val: {type: string}
+          err: {type: string, description: Statistical error}
       pa:
         type: object
         additionalProperties: false
         unit: deg
         description: |
           Position angle
-          Number in deg or string that can be parsed by Angle
+          String that can be parsed by Angle
         properties:
           frame: {enum: [radec, galactic]}
-          val: {type: number}
-          err: {type: number, description: Statistical error}
+          val: {type: string}
+          err: {type: string, description: Statistical error}
 
   orbit:
     type: object
@@ -127,7 +127,7 @@ properties:
           - pl2 = `PowerLaw2` in Gammapy
           - ecpl = `ExponentialCutoffPowerLaw` in Gammapy
           - other = some other shape
-      theta: {type: number, unit=deg, description="Circular aperture photometry radius"}
+      theta: {type: string, description="Circular aperture photometry radius (parsed by Angle)"}
       erange:
         type: object
         additionalProperties: false

--- a/input/schemas/dataset_source_info.template.yaml
+++ b/input/schemas/dataset_source_info.template.yaml
@@ -14,10 +14,8 @@ morph:
 
 spec:
   type:
-
   norm: {val: , err: }
   index: {val: , err: , err_sys: }
   ecut: {val: , err: }
-
   theta:
   erange: {min: , max: }


### PR DESCRIPTION
This is a suggestion to make the input data files more clear and less error-prone.

Currently for the source extensions `sigma` and `sigma2` we have a mix of "deg" and "arcmin", and sometimes no unit explicitly put down, produced with
```
ack sigma input/data
```
https://gist.github.com/cdeil/3bdd807b2b3fe2d0a0280b9d90361389

Currently, our schema is this:
https://github.com/gammapy/gamma-cat/blob/master/input/schemas/dataset_source_info.schema.yaml#L66
```
  morph:
    type: object
    additionalProperties: false
    properties:
      type: {enum: [point, gauss, shell]}
      sigma:
        type: object
        additionalProperties: false
        description: |
          Width parameter (semantics type-dependent)
          Number in deg or string that can be parsed by Angle
        properties:
          val: {type: [string, number]}
          err: {type: [string, number], description: Statistical error}
      sigma2:
        type: object
        additionalProperties: false
        description: |
          Width parameter (semantics type-dependent)
          Number in deg or string that can be parsed by Angle
        properties:
          val: {type: [string, number]}
          err: {type: [string, number], description: Statistical error}
```

I think e.g. the first source listed is incorrect, it's probably 6 arcmin in size, and not 6 deg:
```
$ ack sigma input/data
input/data/2005/2005A%26A...435L..17A/tev-000079.yaml
15:  sigma: {val: 6.4, err: 0.7}
16:  sigma2: {val: 2.3, err: 0.5}
```

---

My suggestion here would be to always do data entry with an angle, using this format:
```
In [1]: from astropy.coordinates import Angle

In [2]: Angle('3d')
Out[2]: <Angle 3.0 deg>

In [3]: Angle('3m')
Out[3]: <Angle 3.0 arcmin>
```
I.e. if the paper gives the value in "deg", put it in "deg", and if it's in "arcmin", put it in "arcmin".

The schema can be changed to only take string as input, and the description changed to say that format should be "<val>s" and "<val>m".

---

I think the number of cases where one needs to look at the paper again to figure out what the units are or double-check is small. This could be done as one PR, I think that will be OK to review and get in quickly.

@pdeiml - You or me?

(I won't have time this week, but could try to get it done next week.)
