### PR TITLE
Data entry for paper 2015Sci...347..406H, source 24

### DIFF
--- a/input/data/2015/2015Sci...347..406H/tev-000024.yaml
+++ b/input/data/2015/2015Sci...347..406H/tev-000024.yaml
@@ -1,4 +1,15 @@
 source_id: 24
 reference_id: 2015Sci...347..406H
 
-# TODO: add data
+data:
+  livetime: 148
+  significance: 4.7
+  excess: 43
+
+spec:
+  type: pl
+
+  norm: {val: 0.13, err: 0.05, err_sys: 0.039}
+  index: {val: 2.4, err: 0.3, err_sys: 0.3}
+  ref: 1
+  


### PR DESCRIPTION
Irgendwie kann ich keine inline-Kommentare machen, wenn ich den PR erzeugen will.

Folgendes:
1) In dem Paper https://arxiv.org/pdf/1501.06578.pdf heisst es im Absatz  "HESS Observations":
"We report on a deep, 210-hours H.E.S.S. exposure, targeted at the region..."
Allerdings ist in Tabelle 1 eine exposure time von 43 angegeben, mit dem Kommentar: 
"The exposure time is corrected for the acceptance differences due to different offsets from the camera centre"
Welche der beiden Zeiten sind korrekt (ich habe die aus der Tabelle eingetragen).

2) Ich finde keine Positionsangabe für diese Quelle, weil die einzige Position im ganzen Paper ist im Absatz "HESS Observations" gegeben durch:
"The position of the second source (RA = 5h35m(55 ± 5)s, Dec = −69◦ 11′ (10 ± 20)′′ , equinox J2000, 1 σ errors) coin- cides with the superbubble 30 Dor C,..."
und das lese ich so, dass diese Position eben zur Quelle DorC gehört?
