### PR TITLE
Update Python 3.5 -> 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
 # Workaround for the following issue:
 # https://travis-ci.org/gammapy/gamma-cat/builds/225367662#L755
 # Reported here: https://github.com/bokeh/bokeh/issues/6193
-- export BOKEH_DOCS_MISSING_API_KEY_OK=yes
+#- export BOKEH_DOCS_MISSING_API_KEY_OK=yes
 
 - export PYTHONPATH=.:$PYTHONPATH
 - python make.py --help

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ An open data collection and source catalog for gamma-ray astronomy.
 ## See also
 
 * http://gamma-sky.net/
-* http://gamma-sky.net/cat/tev
 * http://docs.gammapy.org/en/latest/catalog/index.html
 
 ## Infos for maintainers and contributors

--- a/documentation/contribute/code.rst
+++ b/documentation/contribute/code.rst
@@ -9,6 +9,21 @@ It's a bunch of Python modules in the ``gammacat`` folder.
 This is only useful if you want to contribute to the gamma-cat.
 Users can use ``gammacat.catalog`` to access the catalog information.
 
+Installation
+------------
+
+If you want to run the ``gamma-cat`` Python scripts locally, you need to install
+Python 3.6 and some Python packages. We recommend you download `Anaconda <https://www.continuum.io/downloads>`__
+and then install the packages via::
+
+    conda env create -f environment.yml
+    source activate gamma-cat
+
+We have continuous integration tests set up on travis-ci that check that everything is working OK.
+The `.travis.yml <https://github.com/gammapy/gamma-cat/blob/master/.travis.yml>` file could be helpful
+to you to have an example how to do the installation just from the command line
+(i.e. commands you can copy & paste if you prefer the command line over the Anaconda GUI installer and navigator app).
+
 make.py
 -------
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,6 @@ name: gamma-cat
 
 channels:
   - conda-forge
-  - openastronomy
-  - astropy
 
 dependencies:
   - python=3.6

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
   - astropy
 
 dependencies:
-  - python=3.5
+  - python=3.6
   - pytest
   - pytest-cov
   - cython

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,4 +2,4 @@ conda:
   file: environment.yml
 
 python:
-   version: 3.5
+   version: 3.6


### PR DESCRIPTION
This PR updates the build on travis-ci and RTD from Python 3.5 to 3.6.

It shouldn't really matter, but I wanted to see if the issue from #133 is still present on travis-ci, and it's easier to debug if it's the same version there that I use locally.