### PR TITLE
Add unit to position value in input files

### DIFF
--- a/input/data/2008/2008ApJ...679.1427A/tev-000014.yaml
+++ b/input/data/2008/2008ApJ...679.1427A/tev-000014.yaml
@@ -18,7 +18,7 @@ pos:
 orbit:
   # zero phase for orbital period from Gregory (2002)
   mjd0: 43366.3
-  period: {val: 26.4960 }
+  period: {val: 26.4960d}
 
 #############################################################
 # spectral fit results

--- a/input/data/2009/2009ApJ...700.1034A/tev-000014-1.yaml
+++ b/input/data/2009/2009ApJ...700.1034A/tev-000014-1.yaml
@@ -9,7 +9,7 @@ telescope: veritas
 orbit:
    # zero phase for orbital period from Gregory (2002)
    mjd0: 43366.3     #
-   period: {val: 26.4960 }
+   period: {val: 26.4960d}
 
 #############################################################
 # spectral fit results

--- a/input/data/2009/2009ApJ...700.1034A/tev-000014-2.yaml
+++ b/input/data/2009/2009ApJ...700.1034A/tev-000014-2.yaml
@@ -9,7 +9,7 @@ telescope: veritas
 orbit:
    # zero phase for orbital period from Gregory (2002)
    mjd0: 43366.3     #
-   period: {val: 26.4960 }
+   period: {val: 26.4960d}
 
 #############################################################
 # spectral fit results

--- a/input/data/2011/2011ApJ...738....3A/tev-000014.yaml
+++ b/input/data/2011/2011ApJ...738....3A/tev-000014.yaml
@@ -11,4 +11,4 @@ telescope: veritas
 orbit:
   # zero phase for orbital period from Gregory (2002)
   mjd0: 43366.3
-  period: {val: 26.4960 }
+  period: {val: 26.4960d}

--- a/input/data/2012/2012ApJ...754L..10A/tev-000030.yaml
+++ b/input/data/2012/2012ApJ...754L..10A/tev-000030.yaml
@@ -8,7 +8,7 @@ morph:
 orbit:
   # zero phase for orbital period
   mjd0: 54857     # arbitrarily set to the date of the first Swift observations
-  period: {val: 321}
+  period: {val: 321d}
 
 #############################################################
 # spectral results are given for February 2011

--- a/input/data/2013/2013ApJ...779...88A/tev-000014.yaml
+++ b/input/data/2013/2013ApJ...779...88A/tev-000014.yaml
@@ -6,7 +6,7 @@ telescope: veritas
 orbit:
     # zero phase for orbital period from Gregory (2002)
     mjd0: 43366.3
-    period: {val: 26.4960 }
+    period: {val: 26.4960d}
 
 # (spectral fit for phases 0.5-0.8)
 spec:

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-1.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-1.yaml
@@ -15,7 +15,7 @@ morph:
 orbit:
   # zero phase for orbital period
   mjd0: 54857     # arbitrarily set to the date of the first Swift observations
-  period: {val: 315, errp: 6, errn: 4}
+  period: {val: 315d, errp: 6d, errn: 4d}
 
 #############################################################
 # spectral results are given for different orbital phases

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-2.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-2.yaml
@@ -7,7 +7,7 @@ telescope: veritas
 orbit:
   # zero phase for orbital period
   mjd0: 54857     # arbitrarily set to the date of the first Swift observations
-  period: {val: 315, errp: 6, errn: 4}
+  period: {val: 315d, errp: 6d, errn: 4d}
 
 #############################################################
 # spectral results are given for different orbital phases

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-3.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-3.yaml
@@ -7,7 +7,7 @@ telescope: veritas
 orbit:
   # zero phase for orbital period
   mjd0: 54857     # arbitrarily set to the date of the first Swift observations
-  period: {val: 315, errp: 6, errn: 4}
+  period: {val: 315d, errp: 6d, errn: 4d}
 
 #############################################################
 # spectral results are given for different orbital phases

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-4.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-4.yaml
@@ -7,7 +7,7 @@ telescope: veritas
 orbit:
   # zero phase for orbital period
   mjd0: 54857     # arbitarily set to the date of the first Swift observations
-  period: {val: 315, errp: 6, errn: 4}
+  period: {val: 315d, errp: 6d, errn: 4d}
 
 #############################################################
 # spectral results are given for different orbital phases

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-5.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-5.yaml
@@ -7,7 +7,7 @@ telescope: hess
 orbit:
   # zero phase for orbital period
   mjd0: 54857     # arbitrarily set to the date of the first Swift observations
-  period: {val: 315, errp: 6, errn: 4}
+  period: {val: 315d, errp: 6d, errn: 4d}
 
 #############################################################
 # spectral results are given for different orbital phases

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-6.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-6.yaml
@@ -7,7 +7,7 @@ telescope: hess
 orbit:
   # zero phase for orbital period
   mjd0: 54857     # arbitrarily set to the date of the first Swift observations
-  period: {val: 315, errp: 6, errn: 4}
+  period: {val: 315d, errp: 6d, errn: 4d}
 
 #############################################################
 # spectral results are given for different orbital phases

--- a/input/data/2016/2016ApJ...817L...7A/tev-000014-1.yaml
+++ b/input/data/2016/2016ApJ...817L...7A/tev-000014-1.yaml
@@ -10,7 +10,7 @@ file_id: 1
 orbit:
   # zero phase for orbital period from Gregory (2002)
   mjd0: 43366.3
-  period: {val: 26.4960 }
+  period: {val: 26.4960d}
 
 #############################################################
 # spectral fit results

--- a/input/data/2016/2016ApJ...817L...7A/tev-000014-2.yaml
+++ b/input/data/2016/2016ApJ...817L...7A/tev-000014-2.yaml
@@ -10,7 +10,7 @@ file_id: 2
 orbit:
   # zero phase for orbital period from Gregory (2002)
   mjd0: 43366.3
-  period: {val: 26.4960 }
+  period: {val: 26.4960d}
 
 #############################################################
 # spectral fit results

--- a/input/data/2016/2016ApJ...817L...7A/tev-000014-3.yaml
+++ b/input/data/2016/2016ApJ...817L...7A/tev-000014-3.yaml
@@ -10,7 +10,7 @@ file_id: 3
 orbit:
   # zero phase for orbital period from Gregory (2002)
   mjd0: 43366.3     #
-  period: {val: 26.4960 }
+  period: {val: 26.4960d}
 
 #############################################################
 # spectral fit results

--- a/input/data/2016/2016arXiv161003751S/tev-000030-1.yaml
+++ b/input/data/2016/2016arXiv161003751S/tev-000030-1.yaml
@@ -11,7 +11,7 @@ morph:
 orbit:
     # zero phase for orbital period
     mjd0: 54857     # arbitrarily set to the date of the first Swift observations
-    period: {val: 315, errp: 6, errn: 4 }
+    period: {val: 315d, errp: 6d, errn: 4d}
 
 #############################################################
 # spectral results are given for different orbital phases

--- a/input/data/2016/2016arXiv161003751S/tev-000030-2.yaml
+++ b/input/data/2016/2016arXiv161003751S/tev-000030-2.yaml
@@ -11,7 +11,7 @@ morph:
 orbit:
     # zero phase for orbital period
     mjd0: 54857     # arbitarily set to the date of the first Swift observations
-    period: {val: 315, errp: 6, errn: 4 }
+    period: {val: 315d, errp: 6d, errn: 4d}
 
 #############################################################
 # spectral results are given for different orbital phases

--- a/input/data/2016/2016arXiv161003751S/tev-000030-3.yaml
+++ b/input/data/2016/2016arXiv161003751S/tev-000030-3.yaml
@@ -11,7 +11,7 @@ morph:
 orbit:
     # zero phase for orbital period
     mjd0: 54857     # arbitarily set to the date of the first Swift observations
-    period: {val: 315, errp: 6, errn: 4 }
+    period: {val: 315d, errp: 6d, errn: 4d}
 
 #############################################################
 # spectral results are given for different orbital phases

--- a/input/schemas/dataset_source_info.schema.yaml
+++ b/input/schemas/dataset_source_info.schema.yaml
@@ -164,13 +164,14 @@ properties:
       period:
         type: object
         additionalProperties: false
+        unit: day
         description: Orbital period
         properties:
-          val: {type: number, unit: day, description: Measured value}
-          err: {type: number, unit: day, description: Statistical error}
-          errn: {type: number, unit: day, description: Lower statistical error}
-          errp: {type: number, unit: day, description: Upper statistical error}
-          err_sys: {type: number, unit: day, description: Systematic error}
+          val: {type: string, description: Measured value}
+          err: {type: string, description: Statistical error}
+          errn: {type: string, description: Lower statistical error}
+          errp: {type: string, description: Upper statistical error}
+          err_sys: {type: string, description: Systematic error}
 
   spec:
     type: object


### PR DESCRIPTION
I think period is not used in the output files (grep does not find period in /docs/data). 
Anyway, I changed period type to string to have in the input files e.g.
period: {val: 345d}

python make.py all 
works.

Able to merge?!