### PR TITLE
Issue_112_zenith

### DIFF
--- a/input/data/2009/2009ApJ...698L.133A/tev-000029.yaml
+++ b/input/data/2009/2009ApJ...698L.133A/tev-000029.yaml
@@ -3,7 +3,7 @@ reference_id: 2009ApJ...698L.133A
 telescope: veritas
 
 data:
-  livetime: 37.9
+  livetime: 37.9h
   significance: 8.3
   significance_post_trial: 7.5
   excess: 247

--- a/input/data/2009/2009ApJ...703L...6A/tev-000149.yaml
+++ b/input/data/2009/2009ApJ...703L...6A/tev-000149.yaml
@@ -3,7 +3,7 @@ reference_id: 2009ApJ...703L...6A
 telescope: veritas
 
 data:
-  livetime: 33.4
+  livetime: 33.4h
   significance: 7.3
   excess: 228
 

--- a/input/data/2010/2010ApJ...714..163A/tev-000153.yaml
+++ b/input/data/2010/2010ApJ...714..163A/tev-000153.yaml
@@ -3,7 +3,7 @@ reference_id: 2010ApJ...714..163A
 telescope: veritas
 
 data:
-  livetime: 22.0
+  livetime: 22.0h
   significance: 8.3
 
 pos:

--- a/input/data/2011/2011ApJ...730L..20A/tev-000003.yaml
+++ b/input/data/2011/2011ApJ...730L..20A/tev-000003.yaml
@@ -3,7 +3,7 @@ reference_id: 2011ApJ...730L..20A
 telescope: veritas
 
 data:
-  livetime: 66.6
+  livetime: 66.6h
   significance: 5.8
 
 pos:

--- a/input/data/2015/2015ApJ...815L..22A/tev-000167.yaml
+++ b/input/data/2015/2015ApJ...815L..22A/tev-000167.yaml
@@ -3,7 +3,7 @@ reference_id: 2015ApJ...815L..22A
 telescope: veritas
 
 data:
-  livetime: 15.
+  livetime: 15.h
   significance: 7.0
 
 spec:

--- a/input/data/2016/2016arXiv160900600H/tev-000133.yaml
+++ b/input/data/2016/2016arXiv160900600H/tev-000133.yaml
@@ -4,7 +4,7 @@ telescope: hess
 
 data:
   livetime: 75h
-  zenith: 37
+  zenith: 37d
   offset: 1.1
   n_on: 1141
   n_off: 16017

--- a/input/schemas/dataset_source_info.schema.yaml
+++ b/input/schemas/dataset_source_info.schema.yaml
@@ -28,9 +28,10 @@ properties:
           String that can be parsed by Astropy Units.
 
       zenith:
-        type: number
-        unit: deg
-        description: Mean zenith angle
+        type: string
+        description: |
+          Mean zenith angle
+          String that can be parsed by Astropy Units.
 
       offset:
         type: number


### PR DESCRIPTION
Zenith is not used in the output files, I think.
Hence, I cannot check wether different units are parsed correctly.

@cdeil do you think the description like
      livetime:
        type: string
        description: |
          Livetime (observation time minus dead)
          String that can be parsed by Astropy Units.

is enough or should we add an example at the end, like:
          String that can be parsed by Astropy Units (e.g. h, min,...)


Ready to merge.