### PR TITLE
issue_112_erange

### DIFF
--- a/gammacat/catalog.py
+++ b/gammacat/catalog.py
@@ -330,29 +330,22 @@ class CatalogSource:
         else:
             raise ValueError('Unknown spectral model type: {}'.format(spec_type))
 
-        print(type(data['spec_ecpl_norm'])) #peter.deiml@fau.de
-
     @staticmethod
     def fill_spectral_other_info(data, dsi):
         try:
-            erange_min_val = dsi['spec']['erange']['min']
-            erange_min_unit = dsi['spec']['erange']['unit']
-            data['spec_erange_min'] = (erange_min_val * u.Unit(erange_min_unit)).to('TeV')
+            q = Quantity(dsi['spec']['erange']['min'],  dsi['spec']['erange']['unit'])
+            data['spec_erange_min'] = q.to('TeV').value
         except KeyError:
             data['spec_erange_min'] = NA.fill_value['number']
         try:
-            erange_max_val = dsi['spec']['erange']['max']
-            erange_max_unit = dsi['spec']['erange']['unit']
-            data['spec_erange_max'] = (erange_min_val * u.Unit(erange_max_unit)).to('TeV')
+            q = Quantity(dsi['spec']['erange']['max'],  dsi['spec']['erange']['unit'])
+            data['spec_erange_max'] = q.to('TeV').value
         except KeyError:
             data['spec_erange_max'] = NA.fill_value['number']
         try:
             data['spec_theta'] = Angle(dsi['spec']['theta']).degree
         except KeyError:
             data['spec_theta'] = NA.fill_value['number']
-
-        print(type(data['spec_erange_min'])) #peter.deiml@fau.de
-        print(type(data['spec_erange_max'])) #peter.deiml@fau.de
 
     def fill_derived_spectral_info(self):
         """
@@ -637,20 +630,17 @@ class CatalogMaker:
                 unit = rows[0][colname].unit
                 for idx, row in enumerate(rows):
                     d = row[colname]
-                    print('Step6') #peter.deiml@fau.de
                     if not hasattr(d, 'unit'):
                         d = d * u.Unit('')
-                        print('Step7') #peter.deiml@fau.de
                     if d.unit != unit:
-                        print('Step8') #peter.deiml@fau.de
                         # This should never happen.
                         # But it did due to a coding error in the past.
                         log.error('colname:', colname)
                         log.error('row:', row)
                         raise RuntimeError('Inconsistent units!')
                     else:
-                        print('Step9') #peter.deiml@fau.de
                         rows[idx][colname] = d.value
+
         meta = OrderedDict()
         meta['name'] = 'gamma-cat'
         meta['description'] = 'A catalog of TeV gamma-ray sources'

--- a/gammacat/catalog.py
+++ b/gammacat/catalog.py
@@ -245,7 +245,6 @@ class CatalogSource:
             data['significance'] = NA.fill_value['number']
 
         try:
-            # data['livetime'] = dsi['data']['livetime']
             data['livetime'] = Quantity(dsi['data']['livetime']).to('hour').value
         except KeyError:
             data['livetime'] = NA.fill_value['number']
@@ -331,20 +330,29 @@ class CatalogSource:
         else:
             raise ValueError('Unknown spectral model type: {}'.format(spec_type))
 
+        print(type(data['spec_ecpl_norm'])) #peter.deiml@fau.de
+
     @staticmethod
     def fill_spectral_other_info(data, dsi):
         try:
-            data['spec_erange_min'] = dsi['spec']['erange']['min']
+            erange_min_val = dsi['spec']['erange']['min']
+            erange_min_unit = dsi['spec']['erange']['unit']
+            data['spec_erange_min'] = (erange_min_val * u.Unit(erange_min_unit)).to('TeV')
         except KeyError:
             data['spec_erange_min'] = NA.fill_value['number']
         try:
-            data['spec_erange_max'] = dsi['spec']['erange']['max']
+            erange_max_val = dsi['spec']['erange']['max']
+            erange_max_unit = dsi['spec']['erange']['unit']
+            data['spec_erange_max'] = (erange_min_val * u.Unit(erange_max_unit)).to('TeV')
         except KeyError:
             data['spec_erange_max'] = NA.fill_value['number']
         try:
             data['spec_theta'] = Angle(dsi['spec']['theta']).degree
         except KeyError:
             data['spec_theta'] = NA.fill_value['number']
+
+        print(type(data['spec_erange_min'])) #peter.deiml@fau.de
+        print(type(data['spec_erange_max'])) #peter.deiml@fau.de
 
     def fill_derived_spectral_info(self):
         """
@@ -620,7 +628,6 @@ class CatalogMaker:
     def make_table(sources):
         """Convert Python data structures to a flat table."""
         rows = [source.row_dict() for source in sources]
-
         # Passing Quantity objects to `Table(rows=rows)` doesn't work.
         # So for now, we drop units here
         # (we could also make Table column by column ourselves
@@ -630,24 +637,24 @@ class CatalogMaker:
                 unit = rows[0][colname].unit
                 for idx, row in enumerate(rows):
                     d = row[colname]
+                    print('Step6') #peter.deiml@fau.de
                     if not hasattr(d, 'unit'):
                         d = d * u.Unit('')
-
+                        print('Step7') #peter.deiml@fau.de
                     if d.unit != unit:
+                        print('Step8') #peter.deiml@fau.de
                         # This should never happen.
                         # But it did due to a coding error in the past.
                         log.error('colname:', colname)
                         log.error('row:', row)
                         raise RuntimeError('Inconsistent units!')
                     else:
+                        print('Step9') #peter.deiml@fau.de
                         rows[idx][colname] = d.value
-
         meta = OrderedDict()
         meta['name'] = 'gamma-cat'
         meta['description'] = 'A catalog of TeV gamma-ray sources'
         meta['version'] = gammacat_info.version
-        meta['url'] = 'https://github.com/gammapy/gamma-cat/'
-
         schema = CatalogSchema()
         # schema.filter_row_keys(rows)
         # table = Table(rows=rows, meta=meta, names=schema.names, dtype=schema.dtype)
@@ -660,7 +667,6 @@ class CatalogMaker:
         #     print(colname)
         #     print(d)
         #     Table(data={colname: d})
-
         table = Table(rows=rows)
         table = schema.format_table(table)
 

--- a/input/data/2005/2005A%26A...432L..25A/tev-000110.yaml
+++ b/input/data/2005/2005A%26A...432L..25A/tev-000110.yaml
@@ -22,4 +22,4 @@ spec:
       index: {val: 2.40, err: 0.11, err_sys: 0.20}
       e_min: {val: 0.2, unit: TeV}
   theta: 0.1d
-  erange: {min: 0.35}
+  erange: {min: 0.35, unit: TeV}

--- a/input/data/2005/2005A%26A...435L..17A/tev-000079.yaml
+++ b/input/data/2005/2005A%26A...435L..17A/tev-000079.yaml
@@ -24,5 +24,5 @@ spec:
       norm: {val: 5.7, err: 0.2, err_sys: 1.4, scale: 1e-12, unit: cm-2 s-1 TeV-1}
       index: {val: 2.27, err: 0.03, err_sys: 0.20}
       e_ref: {val: 1, unit: TeV}
-  erange: {min: 0.280, max: 40}
+  erange: {min: 0.280, max: 40, unit: TeV}
   theta: 0.3d

--- a/input/data/2005/2005A%26A...437L...7A/tev-000039.yaml
+++ b/input/data/2005/2005A%26A...437L...7A/tev-000039.yaml
@@ -17,4 +17,4 @@ spec:
       norm: {val: 21, err: 2, err_sys: 6, scale: 1e-12, unit: cm-2 s-1 TeV-1}
       index: {val: 2.1, err: 0.1, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
-  erange: {min: 0.5, max: 15}
+  erange: {min: 0.5, max: 15, unit: TeV}

--- a/input/data/2005/2005A%26A...442L..25A/tev-000118.yaml
+++ b/input/data/2005/2005A%26A...442L..25A/tev-000118.yaml
@@ -23,6 +23,6 @@ spec:
       flux: {val: 3.4, err: 0.2, err_sys: 1.0, scale: 1e-11, unit: cm-2 s-1}
       index: {val: 2.40, err: 0.09, err_sys: 0.2}
       e_min: {val: 230, unit: GeV}
-  erange: {min: 0.23}
+  erange: {min: 0.23, unit: TeV}
   # stats: {chi2: 9.8, ndof: 8} # TODO: add this to the spec schema
   # livetime: 5.4 # TODO: add spectrum livetime to the schema

--- a/input/data/2005/2005Sci...309..746A/tev-000119.yaml
+++ b/input/data/2005/2005Sci...309..746A/tev-000119.yaml
@@ -21,4 +21,4 @@ spec:
       flux: {val: 5.1, err: 0.8, err_sys: 1.3, scale: 1e-12, unit: cm-2 s-1}
       index: {val: 2.12, err: 0.15}
       e_min: {val: 250, unit: GeV}
-  erange: {min: 0.25, max: 4}
+  erange: {min: 0.25, max: 4, unit: TeV}

--- a/input/data/2006/2006A%26A...448L..43A/tev-000037.yaml
+++ b/input/data/2006/2006A%26A...448L..43A/tev-000037.yaml
@@ -30,4 +30,4 @@ spec:
       e_cut: {val: 13.8, err: 2.3, err_sys: 4.1, unit: TeV}
       e_ref: {val: 1, unit: TeV}
   theta: 0.8d
-  erange: {min: 0.550, max: 65}
+  erange: {min: 0.550, max: 65, unit: TeV}

--- a/input/data/2006/2006A%26A...456..245A/tev-000065.yaml
+++ b/input/data/2006/2006A%26A...456..245A/tev-000065.yaml
@@ -27,4 +27,4 @@ spec:
       index: {val: 2.22, err: 0.08, err_sys: 0.1}
       e_ref: {val: 1, unit: TeV}
   theta: 0.16d
-  erange: {min: 0.3}
+  erange: {min: 0.3, unit: TeV}

--- a/input/data/2006/2006A%26A...456..245A/tev-000066.yaml
+++ b/input/data/2006/2006A%26A...456..245A/tev-000066.yaml
@@ -25,4 +25,4 @@ spec:
       index: {val: 2.17, err: 0.06, err_sys: 0.1}
       e_ref: {val: 1, unit: TeV}
   theta: 0.16d
-  erange: {min: 0.3}
+  erange: {min: 0.3, unit: TeV}

--- a/input/data/2006/2006A%26A...457..899A/tev-000025.yaml
+++ b/input/data/2006/2006A%26A...457..899A/tev-000025.yaml
@@ -17,4 +17,4 @@ spec:
       e_cut: {val: 14.3, err: 2.1, unit: TeV}
       e_ref: {val: 1, unit: TeV}
   theta: 0.11d
-  erange: {min: 0.44, max: 40.0}
+  erange: {min: 0.44, max: 40.0, unit: TeV}

--- a/input/data/2006/2006A%26A...460..365A/tev-000118.yaml
+++ b/input/data/2006/2006A%26A...460..365A/tev-000118.yaml
@@ -29,4 +29,4 @@ spec:
       e_cut: {val: 24.8, err: 7.2, unit: TeV}
       e_ref: {val: 1, unit: TeV}
   theta: 0.8d
-  erange: {min: 0.27}
+  erange: {min: 0.27, unit: TeV}

--- a/input/data/2006/2006A%26A...460..743A/tev-000119.yaml
+++ b/input/data/2006/2006A%26A...460..743A/tev-000119.yaml
@@ -24,4 +24,4 @@ spec:
       index: {val: 1.85, err: 0.06, err_sys: 0.1}
       e_cut: {val: 8.7, err: 2.0, unit: TeV}
       e_ref: {val: 1, unit: TeV}
-  erange: {min: 0.2, max: 10}
+  erange: {min: 0.2, max: 10, unit: TeV}

--- a/input/data/2006/2006PhRvL..97v1102A/tev-000106.yaml
+++ b/input/data/2006/2006PhRvL..97v1102A/tev-000106.yaml
@@ -21,4 +21,4 @@ spec:
       flux: {val: 1.87, err: 0.10, err_sys: 0.30, scale: 1e-12, unit: cm-1 s-1}
       index: {val: 2.25, err: 0.04, err_sys: 0.10}
       e_min: {val: 1, unit: TeV}
-  erange: {min: 0.160,  max: 30}
+  erange: {min: 0.160,  max: 30, unit: TeV}

--- a/input/data/2007/2007A%26A...469L...1A/tev-000030.yaml
+++ b/input/data/2007/2007A%26A...469L...1A/tev-000030.yaml
@@ -20,4 +20,4 @@ spec:
       index: {val: 2.53, err: 0.26, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.11d
-  erange: {min: 0.4}
+  erange: {min: 0.4, unit: TeV}

--- a/input/data/2007/2007A%26A...472..489A/tev-000099.yaml
+++ b/input/data/2007/2007A%26A...472..489A/tev-000099.yaml
@@ -25,4 +25,4 @@ spec:
       e_cut: {val: 6, err: 3, err_sys: 1, unit: TeV}
       e_ref: {val: 1, unit: TeV}
   theta: 0.2d
-  erange: {min: 0.45}
+  erange: {min: 0.45, unit: TeV}

--- a/input/data/2007/2007A%26A...472..489A/tev-000115.yaml
+++ b/input/data/2007/2007A%26A...472..489A/tev-000115.yaml
@@ -24,4 +24,4 @@ spec:
       index: {val: 2.2, err: 0.1, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.5d
-  erange: {min: 0.25}
+  erange: {min: 0.25, unit: TeV}

--- a/input/data/2007/2007ApJ...661..236A/tev-000039.yaml
+++ b/input/data/2007/2007ApJ...661..236A/tev-000039.yaml
@@ -17,4 +17,4 @@ spec:
       index: {val: 2.24, err: 0.04, err_sys: 0.15}
       e_ref: {val: 1, unit: TeV}
   theta: 1.0d
-  erange: {min: 0.3, max: 20.0}
+  erange: {min: 0.3, max: 20.0, unit: TeV}

--- a/input/data/2008/2008A%26A...477..353A/tev-000068.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000068.yaml
@@ -24,4 +24,4 @@ spec:
       index: {val: 2.16, err: 0.14, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.2d
-  erange: {min: 0.97 , max: 50}
+  erange: {min: 0.97 , max: 50, unit: TeV}

--- a/input/data/2008/2008A%26A...477..353A/tev-000085.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000085.yaml
@@ -24,4 +24,4 @@ spec:
       index: {val: 2.18, err: 0.12, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.5d
-  erange: {min: 0.6 , max: 50}
+  erange: {min: 0.6 , max: 50, unit: TeV}

--- a/input/data/2008/2008A%26A...477..353A/tev-000092.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000092.yaml
@@ -24,4 +24,4 @@ spec:
       index: {val: 2.07, err: 0.08, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.6d
-  erange: {min: 0.50 , max: 50}
+  erange: {min: 0.50 , max: 50, unit: TeV}

--- a/input/data/2008/2008A%26A...477..353A/tev-000093.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000093.yaml
@@ -27,4 +27,4 @@ spec:
       index: {val: 2.58, err: 0.1025, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.3d
-  erange: {min: 0.50 , max: 60}
+  erange: {min: 0.50 , max: 60, unit: TeV}

--- a/input/data/2008/2008A%26A...477..353A/tev-000103.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000103.yaml
@@ -24,4 +24,4 @@ spec:
       index: {val: 2.26, err: 0.10, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.6d
-  erange: {min: 0.50 , max: 80}
+  erange: {min: 0.50 , max: 80, unit: TeV}

--- a/input/data/2008/2008A%26A...477..353A/tev-000125.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000125.yaml
@@ -24,4 +24,4 @@ spec:
       index: {val: 2.41, err: 0.08, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.7d
-  erange: {min: 0.54 , max: 80}
+  erange: {min: 0.54 , max: 80, unit: TeV}

--- a/input/data/2008/2008A%26A...477..353A/tev-000130.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000130.yaml
@@ -24,4 +24,4 @@ spec:
       index: {val: 2.39, err: 0.08, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.46d
-  erange: {min: 0.60 , max: 80}
+  erange: {min: 0.60 , max: 80, unit: TeV}

--- a/input/data/2008/2008A%26A...477..353A/tev-000131.yaml
+++ b/input/data/2008/2008A%26A...477..353A/tev-000131.yaml
@@ -24,4 +24,4 @@ spec:
       index: {val: 2.17, err: 0.12, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.15d
-  erange: {min: 0.50 , max: 80}
+  erange: {min: 0.50 , max: 80, unit: TeV}

--- a/input/data/2008/2008A%26A...481..401A/tev-000112.yaml
+++ b/input/data/2008/2008A%26A...481..401A/tev-000112.yaml
@@ -22,4 +22,4 @@ spec:
       index: {val: 2.66, err: 0.27, err_sys: 0.20}
       e_ref: {val: 1, unit: TeV}
   theta: 0.2d
-  erange: {min: 0.3 , max: 5}
+  erange: {min: 0.3 , max: 5, unit: TeV}

--- a/input/data/2008/2008A%26A...481..401A/tev-000156.yaml
+++ b/input/data/2008/2008A%26A...481..401A/tev-000156.yaml
@@ -22,4 +22,4 @@ spec:
       index: {val: 2.50, err: 0.17, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.2d
-  erange: {min: 0.3 , max: 5}
+  erange: {min: 0.3 , max: 5, unit: TeV}

--- a/input/data/2008/2008A%26A...483..509A/tev-000108.yaml
+++ b/input/data/2008/2008A%26A...483..509A/tev-000108.yaml
@@ -30,4 +30,4 @@ spec:
       index: {val: 2.71, err: 0.11, err_sys: 0.20}
       e_ref: {val: 1, unit: TeV}
   theta: 0.4d
-  erange: {min: 0.15}
+  erange: {min: 0.15, unit: TeV}

--- a/input/data/2008/2008A%26A...484..435A/tev-000134.yaml
+++ b/input/data/2008/2008A%26A...484..435A/tev-000134.yaml
@@ -23,4 +23,4 @@ spec:
       index: {val: 2.7, err: 0.2, err_sys: 0.3}
       e_ref: {val: 1, unit: TeV}
   theta: 0.5d
-  erange: {min: 0.8}
+  erange: {min: 0.8, unit: TeV}

--- a/input/data/2008/2008A%26A...486..829A/tev-000095.yaml
+++ b/input/data/2008/2008A%26A...486..829A/tev-000095.yaml
@@ -29,4 +29,4 @@ spec:
       index: {val: 2.65, err: 0.19, err_sys: 0.20}
       e_ref: {val: 1, unit: TeV}
   theta: 0.187d
-  erange: {min: 0.25}
+  erange: {min: 0.25, unit: TeV}

--- a/input/data/2008/2008A%26A...490..685A/tev-000097.yaml
+++ b/input/data/2008/2008A%26A...490..685A/tev-000097.yaml
@@ -25,4 +25,4 @@ spec:
       index: {val: 2.30, err: 0.13, err_sys: 0.20}
       e_ref: {val: 1, unit: TeV}
   theta: 0.2d
-  erange: {min: 0.2, max: 40}
+  erange: {min: 0.2, max: 40, unit: TeV}

--- a/input/data/2008/2008AIPC.1085..281R/tev-000075.yaml
+++ b/input/data/2008/2008AIPC.1085..281R/tev-000075.yaml
@@ -21,5 +21,5 @@ spec:
       norm: {val: 1.6, err: 0.6, scale: 1e-12, unit: cm-2 s-1 TeV-1}
       index: {val: 2.4, err: 0.4, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
-  erange: {min: 0.8}
+  erange: {min: 0.8, unit: TeV}
   theta: 0.4d

--- a/input/data/2008/2008AIPC.1085..285R/tev-000064.yaml
+++ b/input/data/2008/2008AIPC.1085..285R/tev-000064.yaml
@@ -22,4 +22,4 @@ spec:
       index: {val: 2.2, err: 0.2, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.22d
-  erange: {min: 0.3, max: 30}
+  erange: {min: 0.3, max: 30, unit: TeV}

--- a/input/data/2008/2008AIPC.1085..372C/tev-000128.yaml
+++ b/input/data/2008/2008AIPC.1085..372C/tev-000128.yaml
@@ -22,4 +22,4 @@ spec:
       index: {val: 2.8, err: 0.2, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.2d
-  erange: {min: 0.9, max: 12}
+  erange: {min: 0.9, max: 12, unit: TeV}

--- a/input/data/2008/2008ApJ...679.1427A/tev-000014.yaml
+++ b/input/data/2008/2008ApJ...679.1427A/tev-000014.yaml
@@ -32,4 +32,4 @@ spec:
       e_ref: {val: 1, unit: TeV}
   mjd: {min: 53999.4, max: 54147.1}
   phase: {min: 0.5, max: 0.8 }
-  erange: {min: 0.3, max: 7.07}
+  erange: {min: 0.3, max: 7.07, unit: TeV}

--- a/input/data/2010/2010A%26A...516A..62A/tev-000074-1.yaml
+++ b/input/data/2010/2010A%26A...516A..62A/tev-000074-1.yaml
@@ -26,4 +26,4 @@ spec:
       flux: {val: 0.233, err: 0.043, err_sys: 0.047, scale: 1e-12, unit: cm-2 s-1}
       index: {val: 2.35, err: 0.14, err_sys: 0.2}
       e_min: {val: 1, unit: TeV}
-  erange: {min: 0.26}
+  erange: {min: 0.26, unit: TeV}

--- a/input/data/2010/2010A%26A...516A..62A/tev-000074-2.yaml
+++ b/input/data/2010/2010A%26A...516A..62A/tev-000074-2.yaml
@@ -17,4 +17,4 @@ spec:
       flux: {val: 0.155, err: 0.037, err_sys: 0.031, scale: 1e-12, unit: cm-2 s-1}
       index: {val: 2.29, err: 0.18, err_sys: 0.2}
       e_min: {val: 1, unit: TeV}
-  erange: {min: 0.26}
+  erange: {min: 0.26, unit: TeV}

--- a/input/data/2010/2010ApJ...714..163A/tev-000153.yaml
+++ b/input/data/2010/2010ApJ...714..163A/tev-000153.yaml
@@ -14,7 +14,7 @@ morph:
   type: point
 
 spec:
-  erange: {min: 0.3, max: 5., unit: TeV}
+  erange: {min: 0.3, max: 5., unit: MeV}
   model:
     type: pl
     parameters:

--- a/input/data/2010/2010ApJ...714..163A/tev-000153.yaml
+++ b/input/data/2010/2010ApJ...714..163A/tev-000153.yaml
@@ -14,7 +14,7 @@ morph:
   type: point
 
 spec:
-  erange: {min: 0.3, max: 5., unit: MeV}
+  erange: {min: 0.3, max: 5., unit: TeV}
   model:
     type: pl
     parameters:

--- a/input/data/2010/2010ApJ...719L..69A/tev-000136.yaml
+++ b/input/data/2010/2010ApJ...719L..69A/tev-000136.yaml
@@ -23,4 +23,4 @@ spec:
       index: {val: 2.39, err: 0.23, err_sys: 0.30}
       e_ref: {val: 1, unit: TeV}
   theta: 0.15d
-  erange: {min: 0.25, max: 4}
+  erange: {min: 0.25, max: 4, unit: TeV}

--- a/input/data/2011/2011A%26A...525A..45H/tev-000077.yaml
+++ b/input/data/2011/2011A%26A...525A..45H/tev-000077.yaml
@@ -22,4 +22,4 @@ spec:
       index: {val: 2.49, err: 0.18, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.22d
-  erange: {min: 0.5}
+  erange: {min: 0.5, unit: TeV}

--- a/input/data/2011/2011A%26A...525A..46H/tev-000046.yaml
+++ b/input/data/2011/2011A%26A...525A..46H/tev-000046.yaml
@@ -22,4 +22,4 @@ spec:
       index: {val: 2.58, err: 0.19, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.33d
-  erange: {min: 0.8}
+  erange: {min: 0.8, unit: TeV}

--- a/input/data/2011/2011A%26A...525A..46H/tev-000047.yaml
+++ b/input/data/2011/2011A%26A...525A..46H/tev-000047.yaml
@@ -22,4 +22,4 @@ spec:
       index: {val: 1.94, err: 0.2, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.33d
-  erange: {min: 0.8}
+  erange: {min: 0.8, unit: TeV}

--- a/input/data/2011/2011A%26A...528A.143H/tev-000094.yaml
+++ b/input/data/2011/2011A%26A...528A.143H/tev-000094.yaml
@@ -22,4 +22,4 @@ spec:
       index: {val: 2.0, err: 0.1, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.71d
-  erange: {min: 0.56}
+  erange: {min: 0.56, unit: TeV}

--- a/input/data/2011/2011A%26A...529A..49H/tev-000137.yaml
+++ b/input/data/2011/2011A%26A...529A..49H/tev-000137.yaml
@@ -26,4 +26,4 @@ spec:
       index: {val: 3.1, err: 0.3, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.1d
-  erange: {min: 0.47}
+  erange: {min: 0.47, unit: TeV}

--- a/input/data/2011/2011A%26A...531A..81H/tev-000102.yaml
+++ b/input/data/2011/2011A%26A...531A..81H/tev-000102.yaml
@@ -25,4 +25,4 @@ spec:
       index: {val: 2.24, err: 0.15, err_sys: 0.2}
       e_ref: {val: 0.861, unit: TeV}
   theta: 0.14d
-  erange: {min: 0.24}
+  erange: {min: 0.24, unit: TeV}

--- a/input/data/2011/2011A%26A...531A..81H/tev-000103.yaml
+++ b/input/data/2011/2011A%26A...531A..81H/tev-000103.yaml
@@ -24,4 +24,4 @@ spec:
       index: {val: 2.32, err: 0.06, err_sys: 0.2}
       e_ref: {val: 0.783, unit: TeV}
   theta: 0.3d
-  erange: {min: 0.24}
+  erange: {min: 0.24, unit: TeV}

--- a/input/data/2011/2011A%26A...533A.103H/tev-000064.yaml
+++ b/input/data/2011/2011A%26A...533A.103H/tev-000064.yaml
@@ -22,4 +22,4 @@ spec:
       norm: {val: 2.7, err: 0.9, err_sys: 0.4, scale: 1e-12, unit: cm-2 s-1 TeV-1}
       index: {val: 2.2, err: 0.2, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
-  erange: {min: 1, max: 20}
+  erange: {min: 1, max: 20, unit: TeV}

--- a/input/data/2012/2012A%26A...537A.114A/tev-000090.yaml
+++ b/input/data/2012/2012A%26A...537A.114A/tev-000090.yaml
@@ -26,5 +26,5 @@ spec:
       index: {val: 2.19, err: 0.08, err_sys: 0.20}
       e_ref: {val: 1, unit: TeV}
   theta: 1.1d
-  erange: {min: 0.45, max: 75}
+  erange: {min: 0.45, max: 75, unit: TeV}
 

--- a/input/data/2012/2012A%26A...541A...5H/tev-000044.yaml
+++ b/input/data/2012/2012A%26A...541A...5H/tev-000044.yaml
@@ -21,4 +21,4 @@ spec:
       index: {val: 2.9, err: 0.4, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.3d
-  erange: {min: 0.6}
+  erange: {min: 0.6, unit: TeV}

--- a/input/data/2012/2012A%26A...541A...5H/tev-000045.yaml
+++ b/input/data/2012/2012A%26A...541A...5H/tev-000045.yaml
@@ -20,4 +20,4 @@ spec:
       index: {val: 2.7, err: 0.5, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
   theta: 0.1d
-  erange: {min: 0.6}
+  erange: {min: 0.6, unit: TeV}

--- a/input/data/2012/2012A%26A...541A..13A/tev-000135.yaml
+++ b/input/data/2012/2012A%26A...541A..13A/tev-000135.yaml
@@ -25,4 +25,4 @@ spec:
       e_ref: {val: 1, unit: TeV}
   # I think MAGIC has an energy-dependent ON-region size,
   # that's why I can't find an on region radius in the paper.
-  erange: {min: 0.075}
+  erange: {min: 0.075, unit: TeV}

--- a/input/data/2012/2012A%26A...545L...2H/tev-000027.yaml
+++ b/input/data/2012/2012A%26A...545L...2H/tev-000027.yaml
@@ -22,4 +22,4 @@ spec:
       index: {val: 2.8, err: 0.2, err_sys: 0.3}
       e_ref: {val: 1, unit: TeV}
   theta: 0.1d
-  erange: {min: 0.6, max: 12.0}
+  erange: {min: 0.6, max: 12.0, unit: TeV}

--- a/input/data/2012/2012A%26A...548A..38A/tev-000037.yaml
+++ b/input/data/2012/2012A%26A...548A..38A/tev-000037.yaml
@@ -25,7 +25,7 @@ spec:
       e_cut: {val: 14.0, err: 1.6, err_sys: 2.6, unit: TeV}
       e_ref: {val: 1, unit: TeV}
   theta: 1.2d
-  erange: {min: 0.75}
+  erange: {min: 0.75, unit: TeV}
 
 #  flux: {e_min: 1.0, val: 21.0, err: 1.9, err_sys: 4.4}
 

--- a/input/data/2012/2012A%26A...548A..46H/tev-000061.yaml
+++ b/input/data/2012/2012A%26A...548A..46H/tev-000061.yaml
@@ -24,4 +24,4 @@ spec:
       e_cut: {val: 7.7, err: 2.2, unit: TeV}
       e_ref: {val: 1, unit: TeV}
   theta: 0.6d
-  erange: {min: 0.84}
+  erange: {min: 0.84, unit: TeV}

--- a/input/data/2012/2012ApJ...754L..10A/tev-000030.yaml
+++ b/input/data/2012/2012ApJ...754L..10A/tev-000030.yaml
@@ -22,4 +22,4 @@ spec:
       e_ref: {val: 1, unit: TeV}
   mjd: {min: 55598., max: 55559.}
   phase: {min: 0.31, max: 0.36 }
-  erange: {min: 0.136, max: 4.}
+  erange: {min: 0.136, max: 4., unit: TeV}

--- a/input/data/2012/2012arXiv1205.0719D/tev-000073.yaml
+++ b/input/data/2012/2012arXiv1205.0719D/tev-000073.yaml
@@ -25,5 +25,5 @@ spec:
       index: {val: 2.8, err: 0.2}
       e_ref: {val: 1, unit: TeV}
 
-  erange: {min: 0.75}
+  erange: {min: 0.75, unit: TeV}
   theta: 0.33d

--- a/input/data/2013/2013arXiv1303.0979O/tev-000089.yaml
+++ b/input/data/2013/2013arXiv1303.0979O/tev-000089.yaml
@@ -19,4 +19,4 @@ morph:
 #  model:
 #    type: pl
 #
-#  erange: {min: 0.64, max: 30}
+#  erange: {min: 0.64, max: 30, unit: TeV}

--- a/input/data/2014/2014A%26A...562A..40H/tev-000117.yaml
+++ b/input/data/2014/2014A%26A...562A..40H/tev-000117.yaml
@@ -22,4 +22,4 @@ spec:
       norm: {val: 0.09, err: 0.02, err_sys: 0.02, scale: 1e-12, unit: cm-2 s-1 TeV-1}
       index: {val: 2.3, err: 0.3, err_sys: 0.2}
       e_ref: {val: 1.9, unit: TeV}
-  erange: {min: 0.42, max: 12.0}
+  erange: {min: 0.42, max: 12.0, unit: TeV}

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-1.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-1.yaml
@@ -31,4 +31,4 @@ spec:
       e_ref: {val: 1, unit: TeV}
   mjd: {min: 55235.0, max: 55280.}
   phase: {min: 0.2, max: 0.4 }
-  erange: {min: 0.53, max: 2.07}
+  erange: {min: 0.53, max: 2.07, unit: TeV}

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-2.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-2.yaml
@@ -23,4 +23,4 @@ spec:
       e_ref: {val: 1, unit: TeV}
   mjd: {min: 55544.0, max: 55656.}
   phase: {min: 0.2, max: 0.4}
-  erange: {min: 0.53, max: 3.55}
+  erange: {min: 0.53, max: 3.55, unit: TeV}

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-3.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-3.yaml
@@ -23,4 +23,4 @@ spec:
       e_ref: {val: 1, unit: TeV}
   mjd: {min: 55890.0, max: 55928.}
   phase: {min: 0.2, max: 0.4 }
-  erange: {min: 0.53, max: 7.08}
+  erange: {min: 0.53, max: 7.08, unit: TeV}

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-4.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-4.yaml
@@ -23,4 +23,4 @@ spec:
       e_ref: {val: 1, unit: TeV}
   mjd: {min: 55235.0, max: 55928.}
   phase: {min: 0.2, max: 0.4 }
-  erange: {min: 0.53, max: 7.08}
+  erange: {min: 0.53, max: 7.08, unit: TeV}

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-5.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-5.yaml
@@ -23,4 +23,4 @@ spec:
       e_ref: {val: 1, unit: TeV}
   mjd: {min: 53087.0, max: 55951.}
   phase: {min: 0.2, max: 0.4}
-  erange: {min: 0.2, max: 12}
+  erange: {min: 0.2, max: 12, unit: TeV}

--- a/input/data/2014/2014ApJ...780..168A/tev-000030-6.yaml
+++ b/input/data/2014/2014ApJ...780..168A/tev-000030-6.yaml
@@ -23,4 +23,4 @@ spec:
       e_ref: {val: 1, unit: TeV}
   mjd: {min: 53087.0, max: 55951.}
   phase: {min: 0.6, max: 0.9 }
-  erange: {min: 0.2, max: 12.}
+  erange: {min: 0.2, max: 12., unit: TeV}

--- a/input/data/2014/2014ApJ...781L..11A/tev-000025-1.yaml
+++ b/input/data/2014/2014ApJ...781L..11A/tev-000025-1.yaml
@@ -16,4 +16,4 @@ spec:
       norm: {val: 34.8, err: 1.4, err_sys: 10.08, scale: 1e-12, unit: cm-2 s-1 TeV-1}
       index: {val: 2.65, err: 0.04, err_sys: 0.3}
       e_ref: {val: 1, unit: TeV}
-  erange: {min: 1.0, max: 20.}
+  erange: {min: 1.0, max: 20., unit: TeV}

--- a/input/data/2014/2014ApJ...781L..11A/tev-000025-2.yaml
+++ b/input/data/2014/2014ApJ...781L..11A/tev-000025-2.yaml
@@ -16,4 +16,4 @@ spec:
       norm: {val: 35.3, err: 1.5, err_sys: 11.2, scale: 1e-12, unit: cm-2 s-1 TeV-1}
       index: {val: 2.72, err: 0.05, err_sys: 0.3}
       e_ref: {val: 1, unit: TeV}
-  erange: {min: 1.0, max: 20.}
+  erange: {min: 1.0, max: 20., unit: TeV}

--- a/input/data/2014/2014ApJ...794L...1A/tev-000089.yaml
+++ b/input/data/2014/2014ApJ...794L...1A/tev-000089.yaml
@@ -21,4 +21,4 @@ spec:
       norm: {val: 0.391, err: 0.069, err_sys: 0.078, scale: 1e-12, unit: cm-2 s-1 TeV-1}
       index: {val: 2.07, err: 0.11, err_sys: 0.2}
       e_ref: {val: 1, unit: TeV}
-  erange: {min: 0.64, max: 100}
+  erange: {min: 0.64, max: 100, unit: TeV}

--- a/input/data/2015/2015A%26A...574A.100H/tev-000098.yaml
+++ b/input/data/2015/2015A%26A...574A.100H/tev-000098.yaml
@@ -20,5 +20,5 @@ spec:
       flux: {val: 0.65, err: 0.11, err_sys: 0.13, scale: 1e-12, unit: cm-2 s-1}
       index: {val: 2.8, err: 0.27, err_sys: 0.2}
       e_min: {val: 0.4, unit: TeV}
-  erange: {min: 0.22}
+  erange: {min: 0.22, unit: TeV}
   theta: 0.1d

--- a/input/data/2015/2015MNRAS.446.1163H/tev-000121.yaml
+++ b/input/data/2015/2015MNRAS.446.1163H/tev-000121.yaml
@@ -20,4 +20,4 @@ spec:
       norm: {val: 0.48, err: 0.08, err_sys: 0.1, scale: 1e-12, unit: cm-2 s-1 TeV-1}
       index: {val: 2.6, err: 0.3, err_sys: 0.1}
       e_ref: {val: 1, unit: TeV}
-  erange: {min: 0.4, max: 5}
+  erange: {min: 0.4, max: 5, unit: TeV}

--- a/input/data/2015/2015arXiv151100309G/tev-000153.yaml
+++ b/input/data/2015/2015arXiv151100309G/tev-000153.yaml
@@ -21,4 +21,4 @@ spec:
       norm: {val: 1.45, err: 0.11, scale: 1e-12, unit: cm-2 s-1 TeV-1}
       index: {val: 2.75, err: 0.10, err_sys: 0.20}
       e_ref: {val: 1, unit: TeV}
-  erange: {min: 0.3, max: 7}
+  erange: {min: 0.3, max: 7, unit: TeV}

--- a/input/data/2015/2015arXiv151201911H/tev-000029.yaml
+++ b/input/data/2015/2015arXiv151201911H/tev-000029.yaml
@@ -26,5 +26,5 @@ spec:
       norm: {val: 0.992, err: 0.090, scale: 1e-12, unit: cm-2 s-1 TeV-1}
       index: {val: 2.80, err: 0.09}
       e_ref: {val: 0.55, unit: TeV}
-  erange: {min: 0.19}
+  erange: {min: 0.19, unit: TeV}
   theta: 0.30d

--- a/input/data/2016/2016arXiv160104461H/tev-000070.yaml
+++ b/input/data/2016/2016arXiv160104461H/tev-000070.yaml
@@ -28,4 +28,4 @@ spec:
       e_cut: {val: 3.47, err: 1.23, unit: TeV}
       e_ref: {val: 1, unit: TeV}
   theta: 0.41d
-  erange: {min: 0.4, max: 50}
+  erange: {min: 0.4, max: 50, unit: TeV}

--- a/input/data/2016/2016arXiv160605404A/tev-000114.yaml
+++ b/input/data/2016/2016arXiv160605404A/tev-000114.yaml
@@ -23,4 +23,4 @@ spec:
       index: {val: 2.3, err: 0.2, err_sys: 0.3}
       e_ref: {val: 1, unit: TeV}
   theta: 0.2d
-  erange: {min: 0.4}
+  erange: {min: 0.4, unit: TeV}

--- a/input/data/2016/2016arXiv160900600H/tev-000133.yaml
+++ b/input/data/2016/2016arXiv160900600H/tev-000133.yaml
@@ -28,4 +28,4 @@ spec:
       index: {val: 3.14, err: 0.24, err_sys: 0.29}
       e_ref: {val: 1, unit: TeV}
   theta: 0.1d
-  erange: {min: 0.29}
+  erange: {min: 0.29, unit: TeV}

--- a/input/data/2016/2016arXiv160908671H/tev-000096.yaml
+++ b/input/data/2016/2016arXiv160908671H/tev-000096.yaml
@@ -23,4 +23,4 @@ spec:
       e_cut: {val: 12.9, err: 1.1, unit: TeV}
       e_ref: {val: 1, unit: TeV}
   theta: 0.6d
-  erange: {min: 0.2, max: 40.0}
+  erange: {min: 0.2, max: 40.0, unit: TeV}

--- a/input/data/2016/2016arXiv161003751S/tev-000030-1.yaml
+++ b/input/data/2016/2016arXiv161003751S/tev-000030-1.yaml
@@ -27,4 +27,4 @@ spec:
       e_ref: {val: 1, unit: TeV}
   mjd: {min: 55236.0, max: 57456.}
   phase: {min: 0.2, max: 0.4 }
-  erange: {min: 0.33, max: 6.31}
+  erange: {min: 0.33, max: 6.31, unit: TeV}

--- a/input/data/2016/2016arXiv161003751S/tev-000030-2.yaml
+++ b/input/data/2016/2016arXiv161003751S/tev-000030-2.yaml
@@ -27,4 +27,4 @@ spec:
       e_ref: {val: 1, unit: TeV}
   mjd: {min: 56330.0, max: 56988.416}
   phase: {min: 0.6, max: 0.8 }
-  erange: {min: 0.24, max: 4.47}
+  erange: {min: 0.24, max: 4.47, unit: TeV}

--- a/input/data/2016/2016arXiv161003751S/tev-000030-3.yaml
+++ b/input/data/2016/2016arXiv161003751S/tev-000030-3.yaml
@@ -27,4 +27,4 @@ spec:
       e_ref: {val: 1, unit: TeV}
   mjd: {min: 54830.0, max: 57430.220}
   phase: {min: 0.8, max: 0.2 }
-  erange: {min: 0.28, max: 6.31}
+  erange: {min: 0.28, max: 6.31, unit: TeV}

--- a/input/data/2016/2016arXiv161005799S/tev-000137.yaml
+++ b/input/data/2016/2016arXiv161005799S/tev-000137.yaml
@@ -21,4 +21,4 @@ spec:
       index: {val: 2.8, err: 0.1}
       e_min: {val: 0.2, unit: TeV}
 
-  erange: {min: 0.2, max: 2.0}
+  erange: {min: 0.2, max: 2.0, unit: TeV}

--- a/input/data/2016/2016arXiv161101863H/tev-000039.yaml
+++ b/input/data/2016/2016arXiv161101863H/tev-000039.yaml
@@ -31,4 +31,4 @@ spec:
     # TODO: add support for covar for spectral models?
     covar: [[2.1443e-24, -3.7242e-14, 2.4071e-14], [-3.7242e-14, 0.0066546, -0.0019996], [2.4071e-14, -0.0019996, 0.00076532]]
   theta: 1.0d
-  erange: {min: 0.316, max: 30}
+  erange: {min: 0.316, max: 30, unit: TeV}

--- a/input/schemas/dataset_source_info.schema.yaml
+++ b/input/schemas/dataset_source_info.schema.yaml
@@ -232,11 +232,12 @@ properties:
       erange:
         type: object
         additionalProperties: false
-        description: TODO
+        description: |
+          Energy range of the measurement.
+          Note that this is usually different from the energy range of integral fluxes quoted.
         properties:
           min: {type: number}
           max: {type: number}
-          # TODO: at the moment we have a mix of data entries how unit spec is made for `erange`. Unify!
           unit: {type: string}
 
       theta:

--- a/input/schemas/dataset_source_info.schema.yaml
+++ b/input/schemas/dataset_source_info.schema.yaml
@@ -234,8 +234,8 @@ properties:
         additionalProperties: false
         description: TODO
         properties:
-          min: {type: number, unit: TeV}
-          max: {type: number, unit: TeV}
+          min: {type: number}
+          max: {type: number}
           # TODO: at the moment we have a mix of data entries how unit spec is made for `erange`. Unify!
           unit: {type: string}
 


### PR DESCRIPTION
@cdeil: 
Can you please check the code in catalog.py.
python make.py breaks exactly at 
https://github.com/pdeiml/gamma-cat/blob/issue_112_erange/gammacat/catalog.py#L670

The input of erange is done at
https://github.com/pdeiml/gamma-cat/blob/issue_112_erange/gammacat/catalog.py#L337

For completeness I added three output lines:
https://github.com/pdeiml/gamma-cat/blob/issue_112_erange/gammacat/catalog.py#L333
https://github.com/pdeiml/gamma-cat/blob/issue_112_erange/gammacat/catalog.py#L354
https://github.com/pdeiml/gamma-cat/blob/issue_112_erange/gammacat/catalog.py#L355

which show that e.g. the type of data['spec_ecpl_norm'] and of the erange values are 
astropy.Units.Quantity object.

I don't know why the part with erange breaks.