### PR TITLE
Fixup conf.py

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -115,9 +115,12 @@ if not on_rtd:
 # http://docs.readthedocs.io/en/latest/builds.html#understanding-what-s-going-on
 if on_rtd:
     import subprocess
-    cmd = f'cd .. && {sys.executable} make.py all --clean --webpage'
-    print(f'Executing: {cmd}')
-    subprocess.call(cmd, shell=True)
+    cmd1 = f'cd .. && {sys.executable} make.py clean'
+    cmd2 = f'{sys.executable} make.py webpage'
+    print(f'Executing: {cmd1}')
+    print(f'Executing: {cmd2}')
+    subprocess.call(cmd1, shell=True)
+    subprocess.call(cmd2, shell=True)
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
You can not access data on RTD, e.g. here
https://gamma-cat.readthedocs.io/data/sources/source_2.html
Clicking on the link to the data will lead to a non existing file.

I am not an expert on RTD and sphinx but I think the lines I changed are wrong.
Locally, it is enough to run 'make.py clean', then 'make.py webpage', followed by 'make html' in the documentation folder.
Hence, in the conf.py, it is not necessary to run 'make.py all' and the 'clean' and 'webpage' commands do not need the two hyphen.
@cdeil Please check whether it is working now (and if not, please fix it in some way)
