### PR TITLE
Src info to output

### DIFF
--- a/docs/data/gammacat-datasets.json
+++ b/docs/data/gammacat-datasets.json
@@ -1,6 +1,13 @@
 [
     {
         "source_id": 1,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000001.yaml"
+    },
+    {
+        "source_id": 1,
         "reference_id": "2013ApJ...764...38A",
         "file_id": -1,
         "type": "ds",
@@ -14,11 +21,11 @@
         "location": "data/2013ApJ...764...38A/gammacat_2013ApJ...764...38A_000001_sed.ecsv"
     },
     {
-        "source_id": 1,
-        "reference_id": "['2013ApJ...764...38A']",
+        "source_id": 2,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000001.yaml"
+        "location": "sources/tev-000002.yaml"
     },
     {
         "source_id": 2,
@@ -28,11 +35,11 @@
         "location": "data/2013A%26A...554A..72H/gammacat_2013A%26A...554A..72H_000002_sed.ecsv"
     },
     {
-        "source_id": 2,
-        "reference_id": "['2013A&A...554A..72H']",
+        "source_id": 3,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000002.yaml"
+        "location": "sources/tev-000003.yaml"
     },
     {
         "source_id": 3,
@@ -63,39 +70,39 @@
         "location": "data/2017ApJ...836...23A/gammacat_2017ApJ...836...23A_000003_sed.ecsv"
     },
     {
-        "source_id": 3,
-        "reference_id": "['2017ApJ...836...23A', '2011ApJ...730L..20A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000003.yaml"
-    },
-    {
         "source_id": 4,
-        "reference_id": "['2012AIPC.1505..490B']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000004.yaml"
     },
     {
         "source_id": 5,
-        "reference_id": "['2015MNRAS.446..217A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000005.yaml"
     },
     {
         "source_id": 6,
-        "reference_id": "['2009Sci...326.1080A', '2012ApJ...757..158A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000006.yaml"
     },
     {
         "source_id": 7,
-        "reference_id": "['2012AIPC.1505..186M']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000007.yaml"
+    },
+    {
+        "source_id": 8,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000008.yaml"
     },
     {
         "source_id": 8,
@@ -105,25 +112,25 @@
         "location": "data/2008A%26A...481L.103A/gammacat_2008A%26A...481L.103A_000008_sed.ecsv"
     },
     {
-        "source_id": 8,
-        "reference_id": "['2008A&A...481L.103A', '2008bves.confE..46L']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000008.yaml"
-    },
-    {
         "source_id": 9,
-        "reference_id": "['2014A&A...567L...8A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000009.yaml"
     },
     {
         "source_id": 10,
-        "reference_id": "['2016JPhCS.718e2022M']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000010.yaml"
+    },
+    {
+        "source_id": 11,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000011.yaml"
     },
     {
         "source_id": 11,
@@ -133,18 +140,18 @@
         "location": "data/2011ApJ...726...58A/gammacat_2011ApJ...726...58A_000011_sed.ecsv"
     },
     {
-        "source_id": 11,
-        "reference_id": "['2009ApJ...693L.104A', '2011ApJ...726...43A', '2011ApJ...726...58A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000011.yaml"
-    },
-    {
         "source_id": 12,
-        "reference_id": "['2009ApJ...692L..29A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000012.yaml"
+    },
+    {
+        "source_id": 13,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000013.yaml"
     },
     {
         "source_id": 13,
@@ -175,11 +182,11 @@
         "location": "data/2014ApJ...782...13A/gammacat_2014ApJ...782...13A_000013_sed.ecsv"
     },
     {
-        "source_id": 13,
-        "reference_id": "['2007A&A...475L...9A', '2011arXiv1110.0038', '2014ApJ...782...13A']",
+        "source_id": 14,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000013.yaml"
+        "location": "sources/tev-000014.yaml"
     },
     {
         "source_id": 14,
@@ -280,11 +287,11 @@
         "location": "data/2016ApJ...817L...7A/gammacat_2016ApJ...817L...7A_000014_ds.yaml"
     },
     {
-        "source_id": 14,
-        "reference_id": "['2006Sci...312.1771A', '2008ApJ...679.1427A', '2009ApJ...700.1034A', '2011ApJ...738....3A', '2013ApJ...779...88A', '2016ApJ...817L...7A']",
+        "source_id": 15,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000014.yaml"
+        "location": "sources/tev-000015.yaml"
     },
     {
         "source_id": 15,
@@ -294,11 +301,11 @@
         "location": "data/2013A%26A...559A.136H/gammacat_2013A%26A...559A.136H_000015_sed.ecsv"
     },
     {
-        "source_id": 15,
-        "reference_id": "['2013A&A...559A.136H']",
+        "source_id": 16,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000015.yaml"
+        "location": "sources/tev-000016.yaml"
     },
     {
         "source_id": 16,
@@ -308,11 +315,11 @@
         "location": "data/2014A%26A...563A..91A/gammacat_2014A%26A...563A..91A_000016_sed.ecsv"
     },
     {
-        "source_id": 16,
-        "reference_id": "['2014A&A...563A..91A']",
+        "source_id": 17,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000016.yaml"
+        "location": "sources/tev-000017.yaml"
     },
     {
         "source_id": 17,
@@ -336,18 +343,18 @@
         "location": "data/2012ApJ...750...94A/gammacat_2012ApJ...750...94A_000017_sed.ecsv"
     },
     {
-        "source_id": 17,
-        "reference_id": "['2012ApJ...750...94A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000017.yaml"
-    },
-    {
         "source_id": 18,
-        "reference_id": "['2012A&A...539L...2A', '2016A&A...589A..33A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000018.yaml"
+    },
+    {
+        "source_id": 19,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000019.yaml"
     },
     {
         "source_id": 19,
@@ -357,11 +364,11 @@
         "location": "data/2007A%26A...473L..25A/gammacat_2007A%26A...473L..25A_000019_sed.ecsv"
     },
     {
-        "source_id": 19,
-        "reference_id": "['2007A&A...473L..25A']",
+        "source_id": 20,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000019.yaml"
+        "location": "sources/tev-000020.yaml"
     },
     {
         "source_id": 20,
@@ -378,11 +385,11 @@
         "location": "data/2012ApJ...755..118A/gammacat_2012ApJ...755..118A_000020_sed.ecsv"
     },
     {
-        "source_id": 20,
-        "reference_id": "['2013arXiv1307.7051M', '2012ApJ...755..118A', '2012A&A...538A.103H']",
+        "source_id": 21,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000020.yaml"
+        "location": "sources/tev-000021.yaml"
     },
     {
         "source_id": 21,
@@ -392,18 +399,18 @@
         "location": "data/2013A%26A...552A.118H/gammacat_2013A%26A...552A.118H_000021_sed.ecsv"
     },
     {
-        "source_id": 21,
-        "reference_id": "['2013A&A...552A.118H']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000021.yaml"
-    },
-    {
         "source_id": 22,
-        "reference_id": "['2011arXiv1110.0040W', 'atel-2301']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000022.yaml"
+    },
+    {
+        "source_id": 23,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000023.yaml"
     },
     {
         "source_id": 23,
@@ -413,11 +420,11 @@
         "location": "data/2013ApJ...776...69A/gammacat_2013ApJ...776...69A_000023_sed.ecsv"
     },
     {
-        "source_id": 23,
-        "reference_id": "['2013ApJ...776...69A', 'atel-2309']",
+        "source_id": 24,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000023.yaml"
+        "location": "sources/tev-000024.yaml"
     },
     {
         "source_id": 24,
@@ -434,11 +441,11 @@
         "location": "data/2015Sci...347..406H/gammacat_2015Sci...347..406H_000024_sed.ecsv"
     },
     {
-        "source_id": 24,
-        "reference_id": "['2015Sci...347..406H']",
+        "source_id": 25,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000024.yaml"
+        "location": "sources/tev-000025.yaml"
     },
     {
         "source_id": 25,
@@ -483,11 +490,11 @@
         "location": "data/2014ApJ...781L..11A/gammacat_2014ApJ...781L..11A_000025_sed.ecsv"
     },
     {
-        "source_id": 25,
-        "reference_id": "['1998ApJ...503..744H', '2004ApJ...614..897A', '2006A&A...457..899A', '2008ICRC....2..803K', '2014ApJ...781L..11A']",
+        "source_id": 26,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000025.yaml"
+        "location": "sources/tev-000026.yaml"
     },
     {
         "source_id": 26,
@@ -504,11 +511,11 @@
         "location": "data/2015Sci...347..406H/gammacat_2015Sci...347..406H_000026_sed.ecsv"
     },
     {
-        "source_id": 26,
-        "reference_id": "['2015Sci...347..406H']",
+        "source_id": 27,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000026.yaml"
+        "location": "sources/tev-000027.yaml"
     },
     {
         "source_id": 27,
@@ -539,18 +546,18 @@
         "location": "data/2015Sci...347..406H/gammacat_2015Sci...347..406H_000027_sed.ecsv"
     },
     {
-        "source_id": 27,
-        "reference_id": "['2012A&A...545L...2H', '2015Sci...347..406H']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000027.yaml"
-    },
-    {
         "source_id": 28,
-        "reference_id": "['2010A&A...521A..69A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000028.yaml"
+    },
+    {
+        "source_id": 29,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000029.yaml"
     },
     {
         "source_id": 29,
@@ -567,11 +574,11 @@
         "location": "data/2009ApJ...698L.133A/gammacat_2009ApJ...698L.133A_000029_sed.ecsv"
     },
     {
-        "source_id": 29,
-        "reference_id": "['2007ApJ...664L..87A', '2009ApJ...700L.127A', '2009ApJ...698L.133A', '2015arXiv151201911H']",
+        "source_id": 30,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000029.yaml"
+        "location": "sources/tev-000030.yaml"
     },
     {
         "source_id": 30,
@@ -665,18 +672,18 @@
         "location": "data/2017arXiv170804045M/gammacat_2017arXiv170804045M_000030_sed.ecsv"
     },
     {
-        "source_id": 30,
-        "reference_id": "['2007A&A...469L...1A', '2009ApJ...690L.101H', '2009ApJ...698L..94A', '2012ApJ...754L..10A', '2014ApJ...780..168A', '2016arXiv161003751S', '2017arXiv170804045M']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000030.yaml"
-    },
-    {
         "source_id": 31,
-        "reference_id": "['2009ApJ...700L.127A', '2015arXiv150803497B', '2016A&A...591A.138A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000031.yaml"
+    },
+    {
+        "source_id": 32,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000032.yaml"
     },
     {
         "source_id": 32,
@@ -693,18 +700,18 @@
         "location": "data/2011ApJ...742..127A/gammacat_2011ApJ...742..127A_000032_sed.ecsv"
     },
     {
-        "source_id": 32,
-        "reference_id": "['2011ApJ...742..127A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000032.yaml"
-    },
-    {
         "source_id": 33,
-        "reference_id": "['2013arXiv1308.0287D']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000033.yaml"
+    },
+    {
+        "source_id": 34,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000034.yaml"
     },
     {
         "source_id": 34,
@@ -714,11 +721,11 @@
         "location": "data/2010ApJ...715L..49A/gammacat_2010ApJ...715L..49A_000034_sed.ecsv"
     },
     {
-        "source_id": 34,
-        "reference_id": "['2010ApJ...715L..49A']",
+        "source_id": 35,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000034.yaml"
+        "location": "sources/tev-000035.yaml"
     },
     {
         "source_id": 35,
@@ -728,11 +735,11 @@
         "location": "data/2009ApJ...704L.129A/gammacat_2009ApJ...704L.129A_000035_sed.ecsv"
     },
     {
-        "source_id": 35,
-        "reference_id": "['2009ApJ...704L.129A', '2009arXiv0907.0366M']",
+        "source_id": 36,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000035.yaml"
+        "location": "sources/tev-000036.yaml"
     },
     {
         "source_id": 36,
@@ -742,11 +749,11 @@
         "location": "data/2009ApJ...690L.126A/gammacat_2009ApJ...690L.126A_000036_sed.ecsv"
     },
     {
-        "source_id": 36,
-        "reference_id": "['2009ApJ...690L.126A', '2015MNRAS.451..739A']",
+        "source_id": 37,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000036.yaml"
+        "location": "sources/tev-000037.yaml"
     },
     {
         "source_id": 37,
@@ -763,18 +770,18 @@
         "location": "data/2012A%26A...548A..38A/gammacat_2012A%26A...548A..38A_000037_sed.ecsv"
     },
     {
-        "source_id": 37,
-        "reference_id": "['2012A&A...548A..38A', '2006A&A...448L..43A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000037.yaml"
-    },
-    {
         "source_id": 38,
-        "reference_id": "['http://www.astronomerstelegram.org/?read=5768']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000038.yaml"
+    },
+    {
+        "source_id": 39,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000039.yaml"
     },
     {
         "source_id": 39,
@@ -819,25 +826,25 @@
         "location": "data/2016arXiv161101863H/gammacat_2016arXiv161101863H_000039_sed.ecsv"
     },
     {
-        "source_id": 39,
-        "reference_id": "['2016arXiv161101863H', '2005A&A...437L...7A', '2007ApJ...661..236A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000039.yaml"
-    },
-    {
         "source_id": 40,
-        "reference_id": "['2009Natur.462..770V', '2009arXiv0912.3807K']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000040.yaml"
     },
     {
         "source_id": 41,
-        "reference_id": "['http://www.astronomerstelegram.org/?read=7080']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000041.yaml"
+    },
+    {
+        "source_id": 42,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000042.yaml"
     },
     {
         "source_id": 42,
@@ -847,11 +854,11 @@
         "location": "data/2012A%26A...542A..94H/gammacat_2012A%26A...542A..94H_000042_sed.ecsv"
     },
     {
-        "source_id": 42,
-        "reference_id": "['2011ICRC....8..109C', '2012A&A...542A..94H']",
+        "source_id": 43,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000042.yaml"
+        "location": "sources/tev-000043.yaml"
     },
     {
         "source_id": 43,
@@ -861,18 +868,18 @@
         "location": "data/2007ApJ...667L..21A/gammacat_2007ApJ...667L..21A_000043_sed.ecsv"
     },
     {
-        "source_id": 43,
-        "reference_id": "['2007ApJ...667L..21A', '2016MNRAS.459.2286A', '2016A&A...591A..10A', '2015arXiv150103554C', '2013arXiv1308.0287D']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000043.yaml"
-    },
-    {
         "source_id": 44,
-        "reference_id": "['2010cosp...38.2803D', '2012A&A...541A...5H', '2015A&A...577A.131H']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000044.yaml"
+    },
+    {
+        "source_id": 45,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000045.yaml"
     },
     {
         "source_id": 45,
@@ -889,11 +896,11 @@
         "location": "data/2015A%26A...577A.131H/gammacat_2015A%26A...577A.131H_000045_sed.ecsv"
     },
     {
-        "source_id": 45,
-        "reference_id": "['2015A&A...577A.131H', '2012A&A...541A...5H', '2015ApJ...813L..26S']",
+        "source_id": 46,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000045.yaml"
+        "location": "sources/tev-000046.yaml"
     },
     {
         "source_id": 46,
@@ -910,11 +917,11 @@
         "location": "data/2011A%26A...525A..46H/gammacat_2011A%26A...525A..46H_000046_sed.ecsv"
     },
     {
-        "source_id": 46,
-        "reference_id": "['2007A&A...467.1075A', '2011A&A...525A..46H']",
+        "source_id": 47,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000046.yaml"
+        "location": "sources/tev-000047.yaml"
     },
     {
         "source_id": 47,
@@ -931,11 +938,11 @@
         "location": "data/2011A%26A...525A..46H/gammacat_2011A%26A...525A..46H_000047_sed.ecsv"
     },
     {
-        "source_id": 47,
-        "reference_id": "['2011A&A...525A..46H']",
+        "source_id": 48,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000047.yaml"
+        "location": "sources/tev-000048.yaml"
     },
     {
         "source_id": 48,
@@ -945,11 +952,11 @@
         "location": "data/2007A%26A...470..475A/gammacat_2007A%26A...470..475A_000048_sed.ecsv"
     },
     {
-        "source_id": 48,
-        "reference_id": "['2007A&A...470..475A']",
+        "source_id": 49,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000048.yaml"
+        "location": "sources/tev-000049.yaml"
     },
     {
         "source_id": 49,
@@ -1113,25 +1120,25 @@
         "location": "data/2017ApJ...834....2A/gammacat_2017ApJ...834....2A_000049_sed.ecsv"
     },
     {
-        "source_id": 49,
-        "reference_id": "['1996ApJ...460..644S', '1996ApJ...472L...9B', '1999A&A...350..757A', '1999ApJ...526L..81M', '2000PhDT.........6P', '2000AIPC..515..113P', '2002A&A...393...89A', '2003ApJ...598..242A', '2005A&A...437...95A', '2006ApJ...641..740R', '2007ApJ...663..125A', '2009ApJ...691L..13D', '2010A&A...519A..32A', '2010JPhG...37l5201C', '2011ApJ...734..110B', '2011ApJ...738...25A', '2012JPhG...39d5201C', '2015NIMPA.770...42S', '2017ApJ...834....2A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000049.yaml"
-    },
-    {
         "source_id": 50,
-        "reference_id": "['https://www.mpi-hd.mpg.de/hfm/HESS/pages/home/som/2009/11/', 'http://cxc.harvard.edu/cdo/snr09/pres/DjannatiAtai_Arache_v2.pdf', '2013ApJ...773...77A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000050.yaml"
     },
     {
         "source_id": 51,
-        "reference_id": "['http://www.astronomerstelegram.org/?read=6062']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000051.yaml"
+    },
+    {
+        "source_id": 52,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000052.yaml"
     },
     {
         "source_id": 52,
@@ -1141,11 +1148,11 @@
         "location": "data/2006ApJ...648L.105A/gammacat_2006ApJ...648L.105A_000052_sed.ecsv"
     },
     {
-        "source_id": 52,
-        "reference_id": "['2016PhRvD..93d3011H', '2011arXiv1109.6808R', '2011arXiv1110.6341R', '2006ApJ...648L.105A']",
+        "source_id": 53,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000052.yaml"
+        "location": "sources/tev-000053.yaml"
     },
     {
         "source_id": 53,
@@ -1176,11 +1183,11 @@
         "location": "data/2013ApJ...779...92A/gammacat_2013ApJ...779...92A_000053_sed.ecsv"
     },
     {
-        "source_id": 53,
-        "reference_id": "['2011arXiv1110.0038W', '2012AIPC.1505..538P', 'http://www.astronomerstelegram.org/?read=3100', '2012A&A...544A.142A', '2013ApJ...779...92A', '2017ApJ...836..205A']",
+        "source_id": 54,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000053.yaml"
+        "location": "sources/tev-000054.yaml"
     },
     {
         "source_id": 54,
@@ -1211,11 +1218,11 @@
         "location": "data/2009ApJ...707..612A/gammacat_2009ApJ...707..612A_000054_sed.ecsv"
     },
     {
-        "source_id": 54,
-        "reference_id": "['2008ApJ...684L..73A', '2009ApJ...707..612A', '2015arXiv150807347J']",
+        "source_id": 55,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000054.yaml"
+        "location": "sources/tev-000055.yaml"
     },
     {
         "source_id": 55,
@@ -1232,11 +1239,11 @@
         "location": "data/2010ApJ...709L.163A/gammacat_2010ApJ...709L.163A_000055_sed.ecsv"
     },
     {
-        "source_id": 55,
-        "reference_id": "['2009ApJ...695.1370A', '2010ApJ...709L.163A', '2011arXiv1110.6786L', '2011ICRC....8..151C', '2014ApJ...788..158A']",
+        "source_id": 56,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000055.yaml"
+        "location": "sources/tev-000056.yaml"
     },
     {
         "source_id": 56,
@@ -1246,18 +1253,18 @@
         "location": "data/2011ApJ...730L...8A/gammacat_2011ApJ...730L...8A_000056_sed.ecsv"
     },
     {
-        "source_id": 56,
-        "reference_id": "['http://www.astronomerstelegram.org/?read=5981', 'http://www.astronomerstelegram.org/?read=2684', '2011ApJ...730L...8A', '2015arXiv150103554C']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000056.yaml"
-    },
-    {
         "source_id": 57,
-        "reference_id": "['http://www.astronomerstelegram.org/?read=5038']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000057.yaml"
+    },
+    {
+        "source_id": 58,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000058.yaml"
     },
     {
         "source_id": 58,
@@ -1274,11 +1281,11 @@
         "location": "data/2012ApJ...746..151A/gammacat_2012ApJ...746..151A_000058_lc.ecsv"
     },
     {
-        "source_id": 58,
-        "reference_id": "['2003A&A...403L...1A', '2006Sci...314.1424A', '2008ApJ...679..397A', '2010ApJ...716..819A', '2012A&A...544A..96A', '2012ApJ...746..141A', '2012ApJ...746..151A']",
+        "source_id": 59,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000058.yaml"
+        "location": "sources/tev-000059.yaml"
     },
     {
         "source_id": 59,
@@ -1288,11 +1295,11 @@
         "location": "data/2008Sci...320.1752M/gammacat_2008Sci...320.1752M_000059_sed.ecsv"
     },
     {
-        "source_id": 59,
-        "reference_id": "['2008AIPC.1085..423E', '2008Sci...320.1752M', '2011A&A...530A...4A', '2016arXiv161005523C']",
+        "source_id": 60,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000059.yaml"
+        "location": "sources/tev-000060.yaml"
     },
     {
         "source_id": 60,
@@ -1316,11 +1323,11 @@
         "location": "data/2013A%26A...551A..94H/gammacat_2013A%26A...551A..94H_000060_ds.yaml"
     },
     {
-        "source_id": 60,
-        "reference_id": "['2005A&A...442....1A', '2009A&A...507..389A', '2013A&A...551A..94H']",
+        "source_id": 61,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000060.yaml"
+        "location": "sources/tev-000061.yaml"
     },
     {
         "source_id": 61,
@@ -1351,11 +1358,11 @@
         "location": "data/2012A%26A...548A..46H/gammacat_2012A%26A...548A..46H_000061_sed.ecsv"
     },
     {
-        "source_id": 61,
-        "reference_id": "['2005A&A...439.1013A', '2012A&A...548A..46H', '2013ApJ...773...77A']",
+        "source_id": 62,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000061.yaml"
+        "location": "sources/tev-000062.yaml"
     },
     {
         "source_id": 62,
@@ -1365,18 +1372,18 @@
         "location": "data/2013MNRAS.434.1889H/gammacat_2013MNRAS.434.1889H_000062_sed.ecsv"
     },
     {
-        "source_id": 62,
-        "reference_id": "['2011ICRC....8..109C', '2013MNRAS.434.1889H']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000062.yaml"
-    },
-    {
         "source_id": 63,
-        "reference_id": "['2009ApJ...695L..40A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000063.yaml"
+    },
+    {
+        "source_id": 64,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000064.yaml"
     },
     {
         "source_id": 64,
@@ -1393,11 +1400,11 @@
         "location": "data/2011A%26A...533A.103H/gammacat_2011A%26A...533A.103H_000064_sed.ecsv"
     },
     {
-        "source_id": 64,
-        "reference_id": "['2008AIPC.1085..285R', '2011A&A...533A.103H', '2013ApJ...773...77A']",
+        "source_id": 65,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000064.yaml"
+        "location": "sources/tev-000065.yaml"
     },
     {
         "source_id": 65,
@@ -1414,11 +1421,11 @@
         "location": "data/2006A%26A...456..245A/gammacat_2006A%26A...456..245A_000065_sed.ecsv"
     },
     {
-        "source_id": 65,
-        "reference_id": "['2006A&A...456..245A', '2013ApJ...773...77A']",
+        "source_id": 66,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000065.yaml"
+        "location": "sources/tev-000066.yaml"
     },
     {
         "source_id": 66,
@@ -1435,11 +1442,11 @@
         "location": "data/2006A%26A...456..245A/gammacat_2006A%26A...456..245A_000066_sed.ecsv"
     },
     {
-        "source_id": 66,
-        "reference_id": "['2006A&A...456..245A', '2012A&A...543L...9N', '2012ApJ...750..162K', '2013ApJ...773...77A']",
+        "source_id": 67,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000066.yaml"
+        "location": "sources/tev-000067.yaml"
     },
     {
         "source_id": 67,
@@ -1470,11 +1477,11 @@
         "location": "data/2014ApJ...785L..16A/gammacat_2014ApJ...785L..16A_000067_sed.ecsv"
     },
     {
-        "source_id": 67,
-        "reference_id": "['2010ApJ...708L.100A', '2014ApJ...785L..16A', '2014A&A...567A.135A', '2015arXiv150807251B', '2016A&A...589A..92R']",
+        "source_id": 68,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000067.yaml"
+        "location": "sources/tev-000068.yaml"
     },
     {
         "source_id": 68,
@@ -1491,11 +1498,11 @@
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000068_sed.ecsv"
     },
     {
-        "source_id": 68,
-        "reference_id": "['2008A&A...477..353A', '2011arXiv1111.1634T', '2011ICRC....6..202T', '2013ApJ...773..139V', '2013arXiv1308.1626V', '2013PASJ...65...61F', '2016arXiv160901125G']",
+        "source_id": 69,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000068.yaml"
+        "location": "sources/tev-000069.yaml"
     },
     {
         "source_id": 69,
@@ -1505,11 +1512,11 @@
         "location": "data/2003A%26A...403..523A/gammacat_2003A%26A...403..523A_000069_sed.ecsv"
     },
     {
-        "source_id": 69,
-        "reference_id": "['2002ApJ...571..753H', '2002A&A...384L..23A', '2003A&A...403..523A']",
+        "source_id": 70,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000069.yaml"
+        "location": "sources/tev-000070.yaml"
     },
     {
         "source_id": 70,
@@ -1526,11 +1533,11 @@
         "location": "data/2016arXiv160104461H/gammacat_2016arXiv160104461H_000070_sed.ecsv"
     },
     {
-        "source_id": 70,
-        "reference_id": "['2009Sci...325..719H', '2009ApJ...692.1500A', '2011ApJ...741...96W', '2014A&A...562A.141M', '2015APh....65...80M', '2016arXiv160104461H', '2016arXiv160106534T']",
+        "source_id": 71,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000070.yaml"
+        "location": "sources/tev-000071.yaml"
     },
     {
         "source_id": 71,
@@ -1547,25 +1554,25 @@
         "location": "data/2016MNRAS.461..202A/gammacat_2016MNRAS.461..202A_000071_sed.ecsv"
     },
     {
-        "source_id": 71,
-        "reference_id": "['http://www.astronomerstelegram.org/?read=2786', '2011arXiv1110.0040W', '2011ICRC....8...43M', '2015arXiv150103554C', '2016MNRAS.461..202A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000071.yaml"
-    },
-    {
         "source_id": 72,
-        "reference_id": "['2010tsra.confE.196H']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000072.yaml"
     },
     {
         "source_id": 73,
-        "reference_id": "['2011ICRC....7..158G', '2012arXiv1205.0719D', '2013ApJ...773...77A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000073.yaml"
+    },
+    {
+        "source_id": 74,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000074.yaml"
     },
     {
         "source_id": 74,
@@ -1582,11 +1589,11 @@
         "location": "data/2010A%26A...516A..62A/gammacat_2010A%26A...516A..62A_000074_sed.ecsv"
     },
     {
-        "source_id": 74,
-        "reference_id": "['2010A&A...516A..62A']",
+        "source_id": 75,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000074.yaml"
+        "location": "sources/tev-000075.yaml"
     },
     {
         "source_id": 75,
@@ -1603,11 +1610,11 @@
         "location": "data/2008AIPC.1085..281R/gammacat_2008AIPC.1085..281R_000075_sed.ecsv"
     },
     {
-        "source_id": 75,
-        "reference_id": "['2008AIPC.1085..281R']",
+        "source_id": 77,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000075.yaml"
+        "location": "sources/tev-000077.yaml"
     },
     {
         "source_id": 77,
@@ -1624,11 +1631,11 @@
         "location": "data/2011A%26A...525A..45H/gammacat_2011A%26A...525A..45H_000077_sed.ecsv"
     },
     {
-        "source_id": 77,
-        "reference_id": "['2009arXiv0912.4229T', '2011AdSpR..47..640D', '2011arXiv1111.1634T', '2011ICRC....6..202T', '2011A&A...525A..45H', '2012A&A...545A..94D', '2013ApJ...773..139V', '2013arXiv1308.1626V', '2013ApJ...773...77A', '2015MNRAS.447.3564E']",
+        "source_id": 78,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000077.yaml"
+        "location": "sources/tev-000078.yaml"
     },
     {
         "source_id": 78,
@@ -1638,11 +1645,11 @@
         "location": "data/2013A%26A...554A.107H/gammacat_2013A%26A...554A.107H_000078_sed.ecsv"
     },
     {
-        "source_id": 78,
-        "reference_id": "['2013A&A...554A.107H']",
+        "source_id": 79,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000078.yaml"
+        "location": "sources/tev-000079.yaml"
     },
     {
         "source_id": 79,
@@ -1652,11 +1659,11 @@
         "location": "data/2005A%26A...435L..17A/gammacat_2005A%26A...435L..17A_000079_sed.ecsv"
     },
     {
-        "source_id": 79,
-        "reference_id": "['2005A&A...435L..17A', '2013ApJ...773...77A']",
+        "source_id": 80,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000079.yaml"
+        "location": "sources/tev-000080.yaml"
     },
     {
         "source_id": 80,
@@ -1673,11 +1680,11 @@
         "location": "data/2015A%26A...573A..31H/gammacat_2015A%26A...573A..31H_000080_sed.ecsv"
     },
     {
-        "source_id": 80,
-        "reference_id": "['2015A&A...573A..31H']",
+        "source_id": 81,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000080.yaml"
+        "location": "sources/tev-000081.yaml"
     },
     {
         "source_id": 81,
@@ -1694,11 +1701,11 @@
         "location": "data/2011ICRC....7..185A/gammacat_2011ICRC....7..185A_000081_sed.ecsv"
     },
     {
-        "source_id": 81,
-        "reference_id": "['2011ICRC....7..185A', '2016ApJ...820..100M']",
+        "source_id": 82,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000081.yaml"
+        "location": "sources/tev-000082.yaml"
     },
     {
         "source_id": 82,
@@ -1729,11 +1736,11 @@
         "location": "data/2015ApJ...802...65A/gammacat_2015ApJ...802...65A_000082_sed.ecsv"
     },
     {
-        "source_id": 82,
-        "reference_id": "['2008A&A...477..481A', '2012ApJ...748...46A', '2015ApJ...802...65A', '2015ApJ...799....7A']",
+        "source_id": 83,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000082.yaml"
+        "location": "sources/tev-000083.yaml"
     },
     {
         "source_id": 83,
@@ -1750,11 +1757,11 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000083_sed.ecsv"
     },
     {
-        "source_id": 83,
-        "reference_id": "['2005Sci...307.1938A', '2006ApJ...636..777A', '2008PASJ...60S.163M', '2008AIPC.1085..241R', '2010ASPC..422..265O', '2011PASJ...63S.879S', '2013ApJ...773...77A']",
+        "source_id": 84,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000083.yaml"
+        "location": "sources/tev-000084.yaml"
     },
     {
         "source_id": 84,
@@ -1771,11 +1778,11 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000084_sed.ecsv"
     },
     {
-        "source_id": 84,
-        "reference_id": "['2005Sci...307.1938A', '2006ApJ...636..777A', '2007MNRAS.380..926L', '2009ApJ...690..891K', '2011ICRC....6..202T', '2011arXiv1111.1634T', '2013ApJ...773...77A']",
+        "source_id": 85,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000084.yaml"
+        "location": "sources/tev-000085.yaml"
     },
     {
         "source_id": 85,
@@ -1792,11 +1799,11 @@
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000085_sed.ecsv"
     },
     {
-        "source_id": 85,
-        "reference_id": "['2008A&A...477..353A', '2011arXiv1110.1252E', '2013ApJ...773...77A']",
+        "source_id": 86,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000085.yaml"
+        "location": "sources/tev-000086.yaml"
     },
     {
         "source_id": 86,
@@ -1813,11 +1820,11 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000086_sed.ecsv"
     },
     {
-        "source_id": 86,
-        "reference_id": "['2006ApJ...636..777A']",
+        "source_id": 87,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000086.yaml"
+        "location": "sources/tev-000087.yaml"
     },
     {
         "source_id": 87,
@@ -1834,11 +1841,11 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000087_sed.ecsv"
     },
     {
-        "source_id": 87,
-        "reference_id": "['2006ApJ...636..777A', '2013ApJ...773...77A']",
+        "source_id": 88,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000087.yaml"
+        "location": "sources/tev-000088.yaml"
     },
     {
         "source_id": 88,
@@ -1862,11 +1869,11 @@
         "location": "data/2014MNRAS.439.2828A/gammacat_2014MNRAS.439.2828A_000088_sed.ecsv"
     },
     {
-        "source_id": 88,
-        "reference_id": "['2006ApJ...636..777A', '2014MNRAS.439.2828A']",
+        "source_id": 89,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000088.yaml"
+        "location": "sources/tev-000089.yaml"
     },
     {
         "source_id": 89,
@@ -1883,11 +1890,11 @@
         "location": "data/2014ApJ...794L...1A/gammacat_2014ApJ...794L...1A_000089_sed.ecsv"
     },
     {
-        "source_id": 89,
-        "reference_id": "['2013arXiv1303.0979O', '2014ApJ...794L..16L', '2014ApJ...794L...1A', '2015ApJ...812...32T', '2015arXiv150908310O', '2016arXiv161005444L']",
+        "source_id": 90,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000089.yaml"
+        "location": "sources/tev-000090.yaml"
     },
     {
         "source_id": 90,
@@ -1897,11 +1904,11 @@
         "location": "data/2012A%26A...537A.114A/gammacat_2012A%26A...537A.114A_000090_sed.ecsv"
     },
     {
-        "source_id": 90,
-        "reference_id": "['2010ASPC..422..265O', '2010ApJ...713L..45L', '2012A&A...537A.114A', '2013MNRAS.434.2289O', '2013PASJ...65...64S']",
+        "source_id": 91,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000090.yaml"
+        "location": "sources/tev-000091.yaml"
     },
     {
         "source_id": 91,
@@ -1946,11 +1953,11 @@
         "location": "data/2012ApJ...758....2B/gammacat_2012ApJ...758....2B_000091_sed.ecsv"
     },
     {
-        "source_id": 91,
-        "reference_id": "['1996ApJ...456L..83Q', '1999A&A...342...69A', '2001ApJ...546..898A', '2001A&A...366...62A', '2008JPhG...35f5202G', '2009ApJ...705.1624A', '2011ApJ...727..129A', '2011ApJ...729....2A', '2012ApJ...758....2B', '2015A&A...573A..50A', '2015ApJ...812...65F', '2017A%26A...603A..31A']",
+        "source_id": 92,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000091.yaml"
+        "location": "sources/tev-000092.yaml"
     },
     {
         "source_id": 92,
@@ -1981,11 +1988,11 @@
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000092_sed.ecsv"
     },
     {
-        "source_id": 92,
-        "reference_id": "['2006ApJ...636..777A', '2008A&A...477..353A']",
+        "source_id": 93,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000092.yaml"
+        "location": "sources/tev-000093.yaml"
     },
     {
         "source_id": 93,
@@ -2016,11 +2023,11 @@
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000093_sed.ecsv"
     },
     {
-        "source_id": 93,
-        "reference_id": "['2006ApJ...636..777A', '2008A&A...477..353A', '2009ApJ...707.1717V', '2011ICRC....6..202T', '2011arXiv1111.1634T']",
+        "source_id": 94,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000093.yaml"
+        "location": "sources/tev-000094.yaml"
     },
     {
         "source_id": 94,
@@ -2030,11 +2037,11 @@
         "location": "data/2011A%26A...528A.143H/gammacat_2011A%26A...528A.143H_000094_sed.ecsv"
     },
     {
-        "source_id": 94,
-        "reference_id": "['2009ApJ...703.1725E', '2009ApJ...702..631Y', '2009arXiv0906.5574H', '2011A&A...528A.143H', '2013ApJ...773...77A']",
+        "source_id": 95,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000094.yaml"
+        "location": "sources/tev-000095.yaml"
     },
     {
         "source_id": 95,
@@ -2065,11 +2072,11 @@
         "location": "data/2008A%26A...486..829A/gammacat_2008A%26A...486..829A_000095_sed.ecsv"
     },
     {
-        "source_id": 95,
-        "reference_id": "['2006ApJ...636..777A', '2008A&A...486..829A', '2010ApJ...710..941H', '2010ApJ...725.1384H', '2011RAA....11..625H', '2012MNRAS.421.2593T', '2013MNRAS.434.2748C', '2015APh....65...80M', '2016ApJ...817...64X']",
+        "source_id": 96,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000095.yaml"
+        "location": "sources/tev-000096.yaml"
     },
     {
         "source_id": 96,
@@ -2093,11 +2100,11 @@
         "location": "data/2016arXiv160908671H/gammacat_2016arXiv160908671H_000096_sed.ecsv"
     },
     {
-        "source_id": 96,
-        "reference_id": "['2004Natur.432...75A', '2006A&A...449..223A', '2007A&A...464..235A', '2016arXiv160908671H']",
+        "source_id": 97,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000096.yaml"
+        "location": "sources/tev-000097.yaml"
     },
     {
         "source_id": 97,
@@ -2107,11 +2114,11 @@
         "location": "data/2008A%26A...490..685A/gammacat_2008A%26A...490..685A_000097_sed.ecsv"
     },
     {
-        "source_id": 97,
-        "reference_id": "['2008A&A...490..685A', '2010ApJ...717..372C', '2012MNRAS.421..935L', '2012ApJ...761..133Y', '2012MNRAS.421.2593T', '2013A&A...553A..34D', '2013MNRAS.434.2188M', '2013AdSpR..51..247B']",
+        "source_id": 98,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000097.yaml"
+        "location": "sources/tev-000098.yaml"
     },
     {
         "source_id": 98,
@@ -2128,11 +2135,11 @@
         "location": "data/2015A%26A...574A.100H/gammacat_2015A%26A...574A.100H_000098_sed.ecsv"
     },
     {
-        "source_id": 98,
-        "reference_id": "['2015A&A...574A.100H', '2014ApJ...783L...2T', '2015ApJ...804..124E']",
+        "source_id": 99,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000098.yaml"
+        "location": "sources/tev-000099.yaml"
     },
     {
         "source_id": 99,
@@ -2142,18 +2149,18 @@
         "location": "data/2007A%26A...472..489A/gammacat_2007A%26A...472..489A_000099_sed.ecsv"
     },
     {
-        "source_id": 99,
-        "reference_id": "['2007A&A...476L..25H', '2007A&A...472..489A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000099.yaml"
-    },
-    {
         "source_id": 100,
-        "reference_id": "['http://www.astronomerstelegram.org/?read=5080', '2016arXiv160306523A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000100.yaml"
+    },
+    {
+        "source_id": 101,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000101.yaml"
     },
     {
         "source_id": 101,
@@ -2177,11 +2184,11 @@
         "location": "data/2015ApJ...808..110A/gammacat_2015ApJ...808..110A_000101_sed.ecsv"
     },
     {
-        "source_id": 101,
-        "reference_id": "['http://www.astronomerstelegram.org/?read=3774', '2013arXiv1308.0287D', '2014A&A...563A..90A', '2015arXiv150805551C', '2015arXiv150807251B', '2015ApJ...808..110A', '2015arXiv150103554C', '2015ApJ...808..110A']",
+        "source_id": 102,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000101.yaml"
+        "location": "sources/tev-000102.yaml"
     },
     {
         "source_id": 102,
@@ -2191,11 +2198,11 @@
         "location": "data/2011A%26A...531A..81H/gammacat_2011A%26A...531A..81H_000102_sed.ecsv"
     },
     {
-        "source_id": 102,
-        "reference_id": "['2011A&A...531A..81H', '2015arXiv150306717M']",
+        "source_id": 103,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000102.yaml"
+        "location": "sources/tev-000103.yaml"
     },
     {
         "source_id": 103,
@@ -2219,18 +2226,18 @@
         "location": "data/2011A%26A...531A..81H/gammacat_2011A%26A...531A..81H_000103_sed.ecsv"
     },
     {
-        "source_id": 103,
-        "reference_id": "['2008ApJ...679L..85T', '2008A&A...477..353A', '2010ApJ...710..941H', '2010ApJ...712..790T', '2011A&A...531A..81H', '2012ApJ...756..149B', '2013A&A...556A..41K', '2013MNRAS.434.2748C', '2015A&A...573A..53K', '2015MNRAS.454.2668O', '2015A&A...580A..74A', '2015arXiv150306717M']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000103.yaml"
-    },
-    {
         "source_id": 104,
-        "reference_id": "['2008AIPC.1085..249T', '2016ApJ...816...52H', '2016MNRAS.tmp....7H']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000104.yaml"
+    },
+    {
+        "source_id": 105,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000105.yaml"
     },
     {
         "source_id": 105,
@@ -2254,11 +2261,11 @@
         "location": "data/2016MNRAS.459.2550A/gammacat_2016MNRAS.459.2550A_000105_sed.ecsv"
     },
     {
-        "source_id": 105,
-        "reference_id": "['2011ICRC....8..169B', '2013arXiv1308.0287D', '2016MNRAS.459.2550A']",
+        "source_id": 106,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000105.yaml"
+        "location": "sources/tev-000106.yaml"
     },
     {
         "source_id": 106,
@@ -2303,18 +2310,18 @@
         "location": "data/2016Natur.531..476H/gammacat_2016Natur.531..476H_000106_sed.ecsv"
     },
     {
-        "source_id": 106,
-        "reference_id": "['2004A&A...425L..13A', '2006PhRvL..97v1102A', '2009A&A...503..817A', '2010MNRAS.402.1877A', '2014ApJ...790..149A', '2015arXiv150903425P', '2015arXiv150806311S', '2016Natur.531..476H', '2016ApJ...821..129A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000106.yaml"
-    },
-    {
         "source_id": 107,
-        "reference_id": "['2006Natur.439..695A', '2010MNRAS.402.1877A', '2016ApJ...821..129A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000107.yaml"
+    },
+    {
+        "source_id": 108,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000108.yaml"
     },
     {
         "source_id": 108,
@@ -2338,18 +2345,18 @@
         "location": "data/2008A%26A...483..509A/gammacat_2008A%26A...483..509A_000108_sed.ecsv"
     },
     {
-        "source_id": 108,
-        "reference_id": "['2006ApJ...636..777A', '2008A&A...483..509A', '2009ApJ...691.1854B', '2011arXiv1111.1634T', '2011ICRC....6..202T', '2011ApJ...735..115H', '2012AIPC.1505..265E', '2012ApJ...761..133Y', '2015APh....65...80M', '2016MNRAS.457.4262H']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000108.yaml"
-    },
-    {
         "source_id": 109,
-        "reference_id": "['2006ApJ...636..777A', '2011A&A...531L..18H', '2011ICRC....7..119D', '2011A&A...533L...5D', '2013A&A...551A..26H', '2013MmSAI..84..236M', '2013MNRAS.432.3462Z', '2014MNRAS.445.2842B']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000109.yaml"
+    },
+    {
+        "source_id": 110,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000110.yaml"
     },
     {
         "source_id": 110,
@@ -2373,18 +2380,18 @@
         "location": "data/2016ApJ...821..129A/gammacat_2016ApJ...821..129A_000110_sed.ecsv"
     },
     {
-        "source_id": 110,
-        "reference_id": "['1987ApJ...314..203H', '2005A&A...432L..25A', '2008A&A...487.1033D', '2010A&A...515A..20F', '2015arXiv150806311S', '2016ApJ...821..129A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000110.yaml"
-    },
-    {
         "source_id": 111,
-        "reference_id": "['2008A&A...481..401A', '2010ApJ...718..348A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000111.yaml"
+    },
+    {
+        "source_id": 112,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000112.yaml"
     },
     {
         "source_id": 112,
@@ -2401,11 +2408,11 @@
         "location": "data/2008A%26A...481..401A/gammacat_2008A%26A...481..401A_000112_sed.ecsv"
     },
     {
-        "source_id": 112,
-        "reference_id": "['1997ApJ...489..143C', '2004ASPC..317...59M', '2008AIPC.1085..104F', '2008A&A...481..401A', '2009ApJ...707L.179F', '2010MNRAS.407...94M', '2010ApJ...718..348A', '2010A&A...516L..11G', '2012MNRAS.421..935L', '2012A&A...543L...9N', '2012ApJ...761..133Y', '2013MNRAS.429.1643N', '2013A&A...553A..34D', '2015APh....65...80M', '2015arXiv150306580G', '2016arXiv161000865M', '2016MNRAS.462..532M']",
+        "source_id": 113,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000112.yaml"
+        "location": "sources/tev-000113.yaml"
     },
     {
         "source_id": 113,
@@ -2422,11 +2429,11 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000113_sed.ecsv"
     },
     {
-        "source_id": 113,
-        "reference_id": "['2005Sci...307.1938A', '2006ApJ...636..777A', '2008ApJ...683..957H', '2010ApJ...717..372C', '2012ApJ...744...80A', '2012ApJ...761..133Y', '2013ApJ...773...77A', '2013ApJ...766...29L', '2015APh....65...80M']",
+        "source_id": 114,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000113.yaml"
+        "location": "sources/tev-000114.yaml"
     },
     {
         "source_id": 114,
@@ -2443,11 +2450,11 @@
         "location": "data/2016arXiv160605404A/gammacat_2016arXiv160605404A_000114_sed.ecsv"
     },
     {
-        "source_id": 114,
-        "reference_id": "['https://www.mpi-hd.mpg.de/hd2012/pages/presentations/Rowell.pdf', '2016arXiv160605404A']",
+        "source_id": 115,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000114.yaml"
+        "location": "sources/tev-000115.yaml"
     },
     {
         "source_id": 115,
@@ -2457,11 +2464,11 @@
         "location": "data/2007A%26A...472..489A/gammacat_2007A%26A...472..489A_000115_sed.ecsv"
     },
     {
-        "source_id": 115,
-        "reference_id": "['2007A&A...472..489A', '2008AIPC.1085..285R', '2010PASJ...62..179A', '2014ApJ...796...34R', '2016A&A...587A..71C']",
+        "source_id": 116,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000115.yaml"
+        "location": "sources/tev-000116.yaml"
     },
     {
         "source_id": 116,
@@ -2478,11 +2485,11 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000116_sed.ecsv"
     },
     {
-        "source_id": 116,
-        "reference_id": "['2005Sci...307.1938A', '2006ApJ...637L..41A', '2006ApJ...636..777A', '2007A&A...470..249F', '2008ApJ...683L.155M', '2008A&A...485..195D', '2009ApJ...700L.158G', '2010ApJ...718..467F', '2012ApJ...753L..14H', '2013ApJ...773...77A', '2015APh....65...80M']",
+        "source_id": 117,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000116.yaml"
+        "location": "sources/tev-000117.yaml"
     },
     {
         "source_id": 117,
@@ -2492,11 +2499,11 @@
         "location": "data/2014A%26A...562A..40H/gammacat_2014A%26A...562A..40H_000117_sed.ecsv"
     },
     {
-        "source_id": 117,
-        "reference_id": "['2011ICRC....7..248H', '2013A&A...557L..15C', '2014A&A...562A..40H']",
+        "source_id": 118,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000117.yaml"
+        "location": "sources/tev-000118.yaml"
     },
     {
         "source_id": 118,
@@ -2534,11 +2541,11 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000118_sed.ecsv"
     },
     {
-        "source_id": 118,
-        "reference_id": "['2005Sci...307.1938A', '2005A&A...442L..25A', '2006ApJ...636..777A', '2006A&A...460..365A', '2008ApJ...675..683P', '2009PASJ...61S.189U', '2011ApJ...738...42G', '2011ApJ...742...62V', '2012arXiv1202.1455M', '2013ApJ...773...77A', '2016ApJ...817....3A', '2016MNRAS.458.2813V']",
+        "source_id": 119,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000118.yaml"
+        "location": "sources/tev-000119.yaml"
     },
     {
         "source_id": 119,
@@ -2569,11 +2576,11 @@
         "location": "data/2006A%26A...460..743A/gammacat_2006A%26A...460..743A_000119_sed.ecsv"
     },
     {
-        "source_id": 119,
-        "reference_id": "['2005Sci...309..746A', '2006A&A...460..743A']",
+        "source_id": 120,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000119.yaml"
+        "location": "sources/tev-000120.yaml"
     },
     {
         "source_id": 120,
@@ -2590,11 +2597,11 @@
         "location": "data/2011ICRC....7..244S/gammacat_2011ICRC....7..244S_000120_sed.ecsv"
     },
     {
-        "source_id": 120,
-        "reference_id": "['2011ICRC....7..244S']",
+        "source_id": 121,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000120.yaml"
+        "location": "sources/tev-000121.yaml"
     },
     {
         "source_id": 121,
@@ -2604,18 +2611,18 @@
         "location": "data/2015MNRAS.446.1163H/gammacat_2015MNRAS.446.1163H_000121_sed.ecsv"
     },
     {
-        "source_id": 121,
-        "reference_id": "['2011arXiv1110.6890L', '2013arXiv1308.0475L', '2015MNRAS.446.1163H', '2016arXiv161003264B', '2016MNRAS.457.1753E']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000121.yaml"
-    },
-    {
         "source_id": 122,
-        "reference_id": "['2008ICRC....2..823D', '2008MNRAS.391L..54T', '2009MNRAS.393..527D', '2011MNRAS.412.1221B', '2012ASPC..466..167K', '2016MNRAS.460.4135P', 'https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000122.yaml"
+    },
+    {
+        "source_id": 123,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000123.yaml"
     },
     {
         "source_id": 123,
@@ -2632,11 +2639,11 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000123_sed.ecsv"
     },
     {
-        "source_id": 123,
-        "reference_id": "['2005Sci...307.1938A', '2006ApJ...643L..53A', '2006ApJ...636..777A', '2007ApJ...657L..25T', '2009ApJ...691.1707M', '2010cosp...38.2801M', '2011ApJ...735...33M', '2012MNRAS.421..935L', '2012ApJ...761..133Y', '2013ApJ...773L..19F', '2013ApJ...773...77A', '2015APh....65...80M', '2016ApJ...817....3A']",
+        "source_id": 124,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000123.yaml"
+        "location": "sources/tev-000124.yaml"
     },
     {
         "source_id": 124,
@@ -2653,11 +2660,11 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000124_sed.ecsv"
     },
     {
-        "source_id": 124,
-        "reference_id": "['2005Sci...307.1938A', '2006ApJ...636..777A', '2008ApJ...681..515G', '2009PASJ...61S.183A', '2012arXiv1202.1455M', '2013ApJ...773...77A', '2014PASJ...66...19F', '2016ApJ...817....3A']",
+        "source_id": 125,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000124.yaml"
+        "location": "sources/tev-000125.yaml"
     },
     {
         "source_id": 125,
@@ -2674,25 +2681,25 @@
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000125_sed.ecsv"
     },
     {
-        "source_id": 125,
-        "reference_id": "['2008A&A...477..353A', '2009ApJ...697.1194S', '2011arXiv1111.1634T', '2011ICRC....6..202T', '2013ApJ...779...27B', '2013ApJ...773...77A', '2013arXiv1303.1258T', '2015AdSpR..55.2493N', '2016ApJ...817....3A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000125.yaml"
-    },
-    {
         "source_id": 126,
-        "reference_id": "['2008ICRC....2..579H', '2013ApJ...779...27B', '2016ApJ...817....3A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000126.yaml"
     },
     {
         "source_id": 127,
-        "reference_id": "['2008ICRC....2..823D', '2008A&A...480L..25L', '2016ApJ...817....3A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000127.yaml"
+    },
+    {
+        "source_id": 128,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000128.yaml"
     },
     {
         "source_id": 128,
@@ -2702,18 +2709,18 @@
         "location": "data/2008AIPC.1085..372C/gammacat_2008AIPC.1085..372C_000128_sed.ecsv"
     },
     {
-        "source_id": 128,
-        "reference_id": "['2008AIPC.1085..372C', '2011MmSAI..82..739L', '2013ApJ...773...77A', '2016ApJ...817....3A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000128.yaml"
-    },
-    {
         "source_id": 129,
-        "reference_id": "['http://www.astronomerstelegram.org/?read=3057', '2011ApJ...729L..16G', '2015APh....65...80M']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000129.yaml"
+    },
+    {
+        "source_id": 130,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000130.yaml"
     },
     {
         "source_id": 130,
@@ -2730,11 +2737,11 @@
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000130_sed.ecsv"
     },
     {
-        "source_id": 130,
-        "reference_id": "['2008A&A...477..353A', '2014A&A...571A..96M']",
+        "source_id": 131,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000130.yaml"
+        "location": "sources/tev-000131.yaml"
     },
     {
         "source_id": 131,
@@ -2751,11 +2758,11 @@
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000131_sed.ecsv"
     },
     {
-        "source_id": 131,
-        "reference_id": "['2008A&A...477..353A', '2016ApJ...817....3A', '2014ApJ...787..166A']",
+        "source_id": 132,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000131.yaml"
+        "location": "sources/tev-000132.yaml"
     },
     {
         "source_id": 132,
@@ -2779,11 +2786,11 @@
         "location": "data/2014ApJ...787..166A/gammacat_2014ApJ...787..166A_000132_sed.ecsv"
     },
     {
-        "source_id": 132,
-        "reference_id": "['2007arXiv0710.4057T', '2009A&A...499..723A', '2014ApJ...787..166A']",
+        "source_id": 133,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000132.yaml"
+        "location": "sources/tev-000133.yaml"
     },
     {
         "source_id": 133,
@@ -2800,11 +2807,11 @@
         "location": "data/2016arXiv160900600H/gammacat_2016arXiv160900600H_000133_sed.ecsv"
     },
     {
-        "source_id": 133,
-        "reference_id": "['2011arXiv1104.5003B', '2011ICRC....7..111B', '2016arXiv160900600H']",
+        "source_id": 134,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000133.yaml"
+        "location": "sources/tev-000134.yaml"
     },
     {
         "source_id": 134,
@@ -2821,18 +2828,18 @@
         "location": "data/2008A%26A...484..435A/gammacat_2008A%26A...484..435A_000134_sed.ecsv"
     },
     {
-        "source_id": 134,
-        "reference_id": "['2008A&A...484..435A', '2016arXiv161200261G']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000134.yaml"
-    },
-    {
         "source_id": 135,
-        "reference_id": "['2012A&A...541A..13A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000135.yaml"
+    },
+    {
+        "source_id": 136,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000136.yaml"
     },
     {
         "source_id": 136,
@@ -2849,11 +2856,11 @@
         "location": "data/2010ApJ...719L..69A/gammacat_2010ApJ...719L..69A_000136_sed.ecsv"
     },
     {
-        "source_id": 136,
-        "reference_id": "['2010ApJ...719L..69A']",
+        "source_id": 137,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000136.yaml"
+        "location": "sources/tev-000137.yaml"
     },
     {
         "source_id": 137,
@@ -2877,11 +2884,11 @@
         "location": "data/2016arXiv161005799S/gammacat_2016arXiv161005799S_000137_sed.ecsv"
     },
     {
-        "source_id": 137,
-        "reference_id": "['2011A&A...529A..49H', '2016arXiv161005799S']",
+        "source_id": 138,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000137.yaml"
+        "location": "sources/tev-000138.yaml"
     },
     {
         "source_id": 138,
@@ -2933,18 +2940,18 @@
         "location": "data/2013ApJ...775....3A/gammacat_2013ApJ...775....3A_000138_sed.ecsv"
     },
     {
-        "source_id": 138,
-        "reference_id": "['2003ApJ...583L...9H', '2003ICRC....5.2615T', '2003A&A...406L...9A', '2005ApJ...621..181D', '2006ApJ...639..761A', '2008ApJ...679.1029T', '2013ApJ...775....3A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000138.yaml"
-    },
-    {
         "source_id": 139,
-        "reference_id": "['2010ATel.2753....1M']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000139.yaml"
+    },
+    {
+        "source_id": 140,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000140.yaml"
     },
     {
         "source_id": 140,
@@ -2954,11 +2961,11 @@
         "location": "data/2010A%26A...511A..52H/gammacat_2010A%26A...511A..52H_000140_sed.ecsv"
     },
     {
-        "source_id": 140,
-        "reference_id": "['2005A&A...436L..17A', '2010A&A...511A..52H', '2011A&A...533A.110H']",
+        "source_id": 141,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000140.yaml"
+        "location": "sources/tev-000141.yaml"
     },
     {
         "source_id": 141,
@@ -2975,18 +2982,18 @@
         "location": "data/2014ApJ...788...78A/gammacat_2014ApJ...788...78A_000141_sed.ecsv"
     },
     {
-        "source_id": 141,
-        "reference_id": "['2014ApJ...788...78A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000141.yaml"
-    },
-    {
         "source_id": 142,
-        "reference_id": "['2012ApJ...753..159A', '2007ApJ...658L..33A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000142.yaml"
+    },
+    {
+        "source_id": 143,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000143.yaml"
     },
     {
         "source_id": 143,
@@ -3003,11 +3010,11 @@
         "location": "data/2014ApJ...788...78A/gammacat_2014ApJ...788...78A_000143_sed.ecsv"
     },
     {
-        "source_id": 143,
-        "reference_id": "['2012ApJ...753..159A', '2014ApJ...788...78A']",
+        "source_id": 144,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000143.yaml"
+        "location": "sources/tev-000144.yaml"
     },
     {
         "source_id": 144,
@@ -3024,18 +3031,18 @@
         "location": "data/2013ApJ...770...93A/gammacat_2013ApJ...770...93A_000144_sed.ecsv"
     },
     {
-        "source_id": 144,
-        "reference_id": "['2013ApJ...770...93A', '2011arXiv1111.1034A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000144.yaml"
-    },
-    {
         "source_id": 145,
-        "reference_id": "['2009ApJ...700L.127A', '2007AIPC..921..172L']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000145.yaml"
+    },
+    {
+        "source_id": 146,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000146.yaml"
     },
     {
         "source_id": 146,
@@ -3052,11 +3059,11 @@
         "location": "data/2014ApJ...783...16A/gammacat_2014ApJ...783...16A_000146_sed.ecsv"
     },
     {
-        "source_id": 146,
-        "reference_id": "['2014ApJ...783...16A', '2008ApJ...675L..25A', '2003ICRC....4.2345R', '2012ApJ...753..159A']",
+        "source_id": 147,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000146.yaml"
+        "location": "sources/tev-000147.yaml"
     },
     {
         "source_id": 147,
@@ -3108,11 +3115,11 @@
         "location": "data/2013PhRvD..88j2003A/gammacat_2013PhRvD..88j2003A_000147_sed.ecsv"
     },
     {
-        "source_id": 147,
-        "reference_id": "['2005A&A...442..895A', '2005A&A...430..865A', '2009ApJ...696L.150A', '2010A&A...520A..83H', '2012A&A...539A.149H', '2012A&A...544A..75A', '2013PhRvD..88j2003A']",
+        "source_id": 148,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000147.yaml"
+        "location": "sources/tev-000148.yaml"
     },
     {
         "source_id": 148,
@@ -3143,11 +3150,11 @@
         "location": "data/2013ApJ...762...92A/gammacat_2013ApJ...762...92A_000148_sed.ecsv"
     },
     {
-        "source_id": 148,
-        "reference_id": "['2007ApJ...666L..17A', '2013ApJ...762...92A']",
+        "source_id": 149,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000148.yaml"
+        "location": "sources/tev-000149.yaml"
     },
     {
         "source_id": 149,
@@ -3164,25 +3171,25 @@
         "location": "data/2009ApJ...703L...6A/gammacat_2009ApJ...703L...6A_000149_sed.ecsv"
     },
     {
-        "source_id": 149,
-        "reference_id": "['2009ApJ...703L...6A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000149.yaml"
-    },
-    {
         "source_id": 150,
-        "reference_id": "['2009ApJ...700L.127A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000150.yaml"
     },
     {
         "source_id": 151,
-        "reference_id": "['2015arXiv150806334A', '2014ATel.6849....1H']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000151.yaml"
+    },
+    {
+        "source_id": 152,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000152.yaml"
     },
     {
         "source_id": 152,
@@ -3192,11 +3199,11 @@
         "location": "data/2012A%26A...539A.118A/gammacat_2012A%26A...539A.118A_000152_sed.ecsv"
     },
     {
-        "source_id": 152,
-        "reference_id": "['2012A&A...539A.118A']",
+        "source_id": 153,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000152.yaml"
+        "location": "sources/tev-000153.yaml"
     },
     {
         "source_id": 153,
@@ -3213,11 +3220,11 @@
         "location": "data/2010ApJ...714..163A/gammacat_2010ApJ...714..163A_000153_sed.ecsv"
     },
     {
-        "source_id": 153,
-        "reference_id": "['2010ApJ...714..163A', '2001A&A...370..112A', '2015arXiv151100309G']",
+        "source_id": 154,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000153.yaml"
+        "location": "sources/tev-000154.yaml"
     },
     {
         "source_id": 154,
@@ -3248,11 +3255,11 @@
         "location": "data/2013A%26A...556A..67A/gammacat_2013A%26A...556A..67A_000154_sed.ecsv"
     },
     {
-        "source_id": 154,
-        "reference_id": "['1998ApJ...501..616C', '2005ApJ...634..947S', '2007ApJ...662..892A', '2011ApJ...738..169A', '2013A&A...556A..67A', '2017MNRAS.471.2117A']",
+        "source_id": 155,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000154.yaml"
+        "location": "sources/tev-000155.yaml"
     },
     {
         "source_id": 155,
@@ -3262,11 +3269,11 @@
         "location": "data/2010A%26A...516A..56H/gammacat_2010A%26A...516A..56H_000155_sed.ecsv"
     },
     {
-        "source_id": 155,
-        "reference_id": "['2010A&A...516A..56H', '2006A&A...455..461A']",
+        "source_id": 156,
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
-        "location": "sources/tev-000155.yaml"
+        "location": "sources/tev-000156.yaml"
     },
     {
         "source_id": 156,
@@ -3283,39 +3290,39 @@
         "location": "data/2008A%26A...481..401A/gammacat_2008A%26A...481..401A_000156_sed.ecsv"
     },
     {
-        "source_id": 156,
-        "reference_id": "['2008A&A...481..401A', '2016JHEAp..11....1H']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000156.yaml"
-    },
-    {
         "source_id": 157,
-        "reference_id": "['2011ICRC....7...76K', '2016ApJ...818...63B']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000157.yaml"
     },
     {
         "source_id": 158,
-        "reference_id": "['2015arXiv150903872P']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000158.yaml"
     },
     {
         "source_id": 159,
-        "reference_id": "['2015arXiv151004518L', '2015arXiv150806311S']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000159.yaml"
     },
     {
         "source_id": 160,
-        "reference_id": "['2015arXiv151004518L', '2015arXiv150806311S']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000160.yaml"
+    },
+    {
+        "source_id": 161,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000161.yaml"
     },
     {
         "source_id": 161,
@@ -3325,32 +3332,32 @@
         "location": "data/2017arXiv170107002A/gammacat_2017arXiv170107002A_000161_sed.ecsv"
     },
     {
-        "source_id": 161,
-        "reference_id": "['https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf', '2016MNRAS.458.2813V', '2017arXiv170107002A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000161.yaml"
-    },
-    {
         "source_id": 162,
-        "reference_id": "['https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000162.yaml"
     },
     {
         "source_id": 163,
-        "reference_id": "['https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000163.yaml"
     },
     {
         "source_id": 164,
-        "reference_id": "['https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000164.yaml"
+    },
+    {
+        "source_id": 165,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000165.yaml"
     },
     {
         "source_id": 165,
@@ -3360,18 +3367,18 @@
         "location": "data/2016ApJ...821..129A/gammacat_2016ApJ...821..129A_000165_ds.yaml"
     },
     {
-        "source_id": 165,
-        "reference_id": "['2016ApJ...821..129A', '2017A&A...601A..33A', '2015ICRC...34..838L']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000165.yaml"
-    },
-    {
         "source_id": 166,
-        "reference_id": "['2008Sci...322.1221A', '2011Sci...334...69V', '2011ApJ...742...43A']",
+        "reference_id": "",
         "file_id": -1,
         "type": "bsi",
         "location": "sources/tev-000166.yaml"
+    },
+    {
+        "source_id": 167,
+        "reference_id": "",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000167.yaml"
     },
     {
         "source_id": 167,
@@ -3393,12 +3400,5 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2015ApJ...815L..22A/gammacat_2015ApJ...815L..22A_000167_sed.ecsv"
-    },
-    {
-        "source_id": 167,
-        "reference_id": "['2015ApJ...815L..23A', '2015ApJ...815L..22A']",
-        "file_id": -1,
-        "type": "bsi",
-        "location": "sources/tev-000167.yaml"
     }
 ]

--- a/docs/data/gammacat-datasets.json
+++ b/docs/data/gammacat-datasets.json
@@ -14,11 +14,25 @@
         "location": "data/2013ApJ...764...38A/gammacat_2013ApJ...764...38A_000001_sed.ecsv"
     },
     {
+        "source_id": 1,
+        "reference_id": "['2013ApJ...764...38A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000001.yaml"
+    },
+    {
         "source_id": 2,
         "reference_id": "2013A&A...554A..72H",
         "file_id": -1,
         "type": "sed",
         "location": "data/2013A%26A...554A..72H/gammacat_2013A%26A...554A..72H_000002_sed.ecsv"
+    },
+    {
+        "source_id": 2,
+        "reference_id": "['2013A&A...554A..72H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000002.yaml"
     },
     {
         "source_id": 3,
@@ -49,6 +63,41 @@
         "location": "data/2017ApJ...836...23A/gammacat_2017ApJ...836...23A_000003_sed.ecsv"
     },
     {
+        "source_id": 3,
+        "reference_id": "['2017ApJ...836...23A', '2011ApJ...730L..20A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000003.yaml"
+    },
+    {
+        "source_id": 4,
+        "reference_id": "['2012AIPC.1505..490B']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000004.yaml"
+    },
+    {
+        "source_id": 5,
+        "reference_id": "['2015MNRAS.446..217A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000005.yaml"
+    },
+    {
+        "source_id": 6,
+        "reference_id": "['2009Sci...326.1080A', '2012ApJ...757..158A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000006.yaml"
+    },
+    {
+        "source_id": 7,
+        "reference_id": "['2012AIPC.1505..186M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000007.yaml"
+    },
+    {
         "source_id": 8,
         "reference_id": "2008A&A...481L.103A",
         "file_id": -1,
@@ -56,11 +105,46 @@
         "location": "data/2008A%26A...481L.103A/gammacat_2008A%26A...481L.103A_000008_sed.ecsv"
     },
     {
+        "source_id": 8,
+        "reference_id": "['2008A&A...481L.103A', '2008bves.confE..46L']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000008.yaml"
+    },
+    {
+        "source_id": 9,
+        "reference_id": "['2014A&A...567L...8A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000009.yaml"
+    },
+    {
+        "source_id": 10,
+        "reference_id": "['2016JPhCS.718e2022M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000010.yaml"
+    },
+    {
         "source_id": 11,
         "reference_id": "2011ApJ...726...58A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2011ApJ...726...58A/gammacat_2011ApJ...726...58A_000011_sed.ecsv"
+    },
+    {
+        "source_id": 11,
+        "reference_id": "['2009ApJ...693L.104A', '2011ApJ...726...43A', '2011ApJ...726...58A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000011.yaml"
+    },
+    {
+        "source_id": 12,
+        "reference_id": "['2009ApJ...692L..29A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000012.yaml"
     },
     {
         "source_id": 13,
@@ -89,6 +173,13 @@
         "file_id": 3,
         "type": "sed",
         "location": "data/2014ApJ...782...13A/gammacat_2014ApJ...782...13A_000013_sed.ecsv"
+    },
+    {
+        "source_id": 13,
+        "reference_id": "['2007A&A...475L...9A', '2011arXiv1110.0038', '2014ApJ...782...13A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000013.yaml"
     },
     {
         "source_id": 14,
@@ -189,6 +280,13 @@
         "location": "data/2016ApJ...817L...7A/gammacat_2016ApJ...817L...7A_000014_ds.yaml"
     },
     {
+        "source_id": 14,
+        "reference_id": "['2006Sci...312.1771A', '2008ApJ...679.1427A', '2009ApJ...700.1034A', '2011ApJ...738....3A', '2013ApJ...779...88A', '2016ApJ...817L...7A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000014.yaml"
+    },
+    {
         "source_id": 15,
         "reference_id": "2013A&A...559A.136H",
         "file_id": -1,
@@ -196,11 +294,25 @@
         "location": "data/2013A%26A...559A.136H/gammacat_2013A%26A...559A.136H_000015_sed.ecsv"
     },
     {
+        "source_id": 15,
+        "reference_id": "['2013A&A...559A.136H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000015.yaml"
+    },
+    {
         "source_id": 16,
         "reference_id": "2014A&A...563A..91A",
         "file_id": 2,
         "type": "sed",
         "location": "data/2014A%26A...563A..91A/gammacat_2014A%26A...563A..91A_000016_sed.ecsv"
+    },
+    {
+        "source_id": 16,
+        "reference_id": "['2014A&A...563A..91A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000016.yaml"
     },
     {
         "source_id": 17,
@@ -224,11 +336,32 @@
         "location": "data/2012ApJ...750...94A/gammacat_2012ApJ...750...94A_000017_sed.ecsv"
     },
     {
+        "source_id": 17,
+        "reference_id": "['2012ApJ...750...94A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000017.yaml"
+    },
+    {
+        "source_id": 18,
+        "reference_id": "['2012A&A...539L...2A', '2016A&A...589A..33A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000018.yaml"
+    },
+    {
         "source_id": 19,
         "reference_id": "2007A&A...473L..25A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2007A%26A...473L..25A/gammacat_2007A%26A...473L..25A_000019_sed.ecsv"
+    },
+    {
+        "source_id": 19,
+        "reference_id": "['2007A&A...473L..25A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000019.yaml"
     },
     {
         "source_id": 20,
@@ -245,6 +378,13 @@
         "location": "data/2012ApJ...755..118A/gammacat_2012ApJ...755..118A_000020_sed.ecsv"
     },
     {
+        "source_id": 20,
+        "reference_id": "['2013arXiv1307.7051M', '2012ApJ...755..118A', '2012A&A...538A.103H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000020.yaml"
+    },
+    {
         "source_id": 21,
         "reference_id": "2013A&A...552A.118H",
         "file_id": -1,
@@ -252,11 +392,32 @@
         "location": "data/2013A%26A...552A.118H/gammacat_2013A%26A...552A.118H_000021_sed.ecsv"
     },
     {
+        "source_id": 21,
+        "reference_id": "['2013A&A...552A.118H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000021.yaml"
+    },
+    {
+        "source_id": 22,
+        "reference_id": "['2011arXiv1110.0040W', 'atel-2301']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000022.yaml"
+    },
+    {
         "source_id": 23,
         "reference_id": "2013ApJ...776...69A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2013ApJ...776...69A/gammacat_2013ApJ...776...69A_000023_sed.ecsv"
+    },
+    {
+        "source_id": 23,
+        "reference_id": "['2013ApJ...776...69A', 'atel-2309']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000023.yaml"
     },
     {
         "source_id": 24,
@@ -271,6 +432,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2015Sci...347..406H/gammacat_2015Sci...347..406H_000024_sed.ecsv"
+    },
+    {
+        "source_id": 24,
+        "reference_id": "['2015Sci...347..406H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000024.yaml"
     },
     {
         "source_id": 25,
@@ -315,6 +483,13 @@
         "location": "data/2014ApJ...781L..11A/gammacat_2014ApJ...781L..11A_000025_sed.ecsv"
     },
     {
+        "source_id": 25,
+        "reference_id": "['1998ApJ...503..744H', '2004ApJ...614..897A', '2006A&A...457..899A', '2008ICRC....2..803K', '2014ApJ...781L..11A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000025.yaml"
+    },
+    {
         "source_id": 26,
         "reference_id": "2015Sci...347..406H",
         "file_id": -1,
@@ -327,6 +502,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2015Sci...347..406H/gammacat_2015Sci...347..406H_000026_sed.ecsv"
+    },
+    {
+        "source_id": 26,
+        "reference_id": "['2015Sci...347..406H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000026.yaml"
     },
     {
         "source_id": 27,
@@ -357,6 +539,20 @@
         "location": "data/2015Sci...347..406H/gammacat_2015Sci...347..406H_000027_sed.ecsv"
     },
     {
+        "source_id": 27,
+        "reference_id": "['2012A&A...545L...2H', '2015Sci...347..406H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000027.yaml"
+    },
+    {
+        "source_id": 28,
+        "reference_id": "['2010A&A...521A..69A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000028.yaml"
+    },
+    {
         "source_id": 29,
         "reference_id": "2009ApJ...698L.133A",
         "file_id": -1,
@@ -369,6 +565,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2009ApJ...698L.133A/gammacat_2009ApJ...698L.133A_000029_sed.ecsv"
+    },
+    {
+        "source_id": 29,
+        "reference_id": "['2007ApJ...664L..87A', '2009ApJ...700L.127A', '2009ApJ...698L.133A', '2015arXiv151201911H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000029.yaml"
     },
     {
         "source_id": 30,
@@ -462,6 +665,20 @@
         "location": "data/2017arXiv170804045M/gammacat_2017arXiv170804045M_000030_sed.ecsv"
     },
     {
+        "source_id": 30,
+        "reference_id": "['2007A&A...469L...1A', '2009ApJ...690L.101H', '2009ApJ...698L..94A', '2012ApJ...754L..10A', '2014ApJ...780..168A', '2016arXiv161003751S', '2017arXiv170804045M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000030.yaml"
+    },
+    {
+        "source_id": 31,
+        "reference_id": "['2009ApJ...700L.127A', '2015arXiv150803497B', '2016A&A...591A.138A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000031.yaml"
+    },
+    {
         "source_id": 32,
         "reference_id": "2011ApJ...742..127A",
         "file_id": -1,
@@ -476,11 +693,32 @@
         "location": "data/2011ApJ...742..127A/gammacat_2011ApJ...742..127A_000032_sed.ecsv"
     },
     {
+        "source_id": 32,
+        "reference_id": "['2011ApJ...742..127A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000032.yaml"
+    },
+    {
+        "source_id": 33,
+        "reference_id": "['2013arXiv1308.0287D']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000033.yaml"
+    },
+    {
         "source_id": 34,
         "reference_id": "2010ApJ...715L..49A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2010ApJ...715L..49A/gammacat_2010ApJ...715L..49A_000034_sed.ecsv"
+    },
+    {
+        "source_id": 34,
+        "reference_id": "['2010ApJ...715L..49A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000034.yaml"
     },
     {
         "source_id": 35,
@@ -490,11 +728,25 @@
         "location": "data/2009ApJ...704L.129A/gammacat_2009ApJ...704L.129A_000035_sed.ecsv"
     },
     {
+        "source_id": 35,
+        "reference_id": "['2009ApJ...704L.129A', '2009arXiv0907.0366M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000035.yaml"
+    },
+    {
         "source_id": 36,
         "reference_id": "2009ApJ...690L.126A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2009ApJ...690L.126A/gammacat_2009ApJ...690L.126A_000036_sed.ecsv"
+    },
+    {
+        "source_id": 36,
+        "reference_id": "['2009ApJ...690L.126A', '2015MNRAS.451..739A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000036.yaml"
     },
     {
         "source_id": 37,
@@ -509,6 +761,20 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2012A%26A...548A..38A/gammacat_2012A%26A...548A..38A_000037_sed.ecsv"
+    },
+    {
+        "source_id": 37,
+        "reference_id": "['2012A&A...548A..38A', '2006A&A...448L..43A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000037.yaml"
+    },
+    {
+        "source_id": 38,
+        "reference_id": "['http://www.astronomerstelegram.org/?read=5768']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000038.yaml"
     },
     {
         "source_id": 39,
@@ -553,6 +819,27 @@
         "location": "data/2016arXiv161101863H/gammacat_2016arXiv161101863H_000039_sed.ecsv"
     },
     {
+        "source_id": 39,
+        "reference_id": "['2016arXiv161101863H', '2005A&A...437L...7A', '2007ApJ...661..236A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000039.yaml"
+    },
+    {
+        "source_id": 40,
+        "reference_id": "['2009Natur.462..770V', '2009arXiv0912.3807K']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000040.yaml"
+    },
+    {
+        "source_id": 41,
+        "reference_id": "['http://www.astronomerstelegram.org/?read=7080']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000041.yaml"
+    },
+    {
         "source_id": 42,
         "reference_id": "2012A&A...542A..94H",
         "file_id": -1,
@@ -560,11 +847,32 @@
         "location": "data/2012A%26A...542A..94H/gammacat_2012A%26A...542A..94H_000042_sed.ecsv"
     },
     {
+        "source_id": 42,
+        "reference_id": "['2011ICRC....8..109C', '2012A&A...542A..94H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000042.yaml"
+    },
+    {
         "source_id": 43,
         "reference_id": "2007ApJ...667L..21A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2007ApJ...667L..21A/gammacat_2007ApJ...667L..21A_000043_sed.ecsv"
+    },
+    {
+        "source_id": 43,
+        "reference_id": "['2007ApJ...667L..21A', '2016MNRAS.459.2286A', '2016A&A...591A..10A', '2015arXiv150103554C', '2013arXiv1308.0287D']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000043.yaml"
+    },
+    {
+        "source_id": 44,
+        "reference_id": "['2010cosp...38.2803D', '2012A&A...541A...5H', '2015A&A...577A.131H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000044.yaml"
     },
     {
         "source_id": 45,
@@ -581,6 +889,13 @@
         "location": "data/2015A%26A...577A.131H/gammacat_2015A%26A...577A.131H_000045_sed.ecsv"
     },
     {
+        "source_id": 45,
+        "reference_id": "['2015A&A...577A.131H', '2012A&A...541A...5H', '2015ApJ...813L..26S']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000045.yaml"
+    },
+    {
         "source_id": 46,
         "reference_id": "2011A&A...525A..46H",
         "file_id": -1,
@@ -593,6 +908,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2011A%26A...525A..46H/gammacat_2011A%26A...525A..46H_000046_sed.ecsv"
+    },
+    {
+        "source_id": 46,
+        "reference_id": "['2007A&A...467.1075A', '2011A&A...525A..46H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000046.yaml"
     },
     {
         "source_id": 47,
@@ -609,11 +931,25 @@
         "location": "data/2011A%26A...525A..46H/gammacat_2011A%26A...525A..46H_000047_sed.ecsv"
     },
     {
+        "source_id": 47,
+        "reference_id": "['2011A&A...525A..46H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000047.yaml"
+    },
+    {
         "source_id": 48,
         "reference_id": "2007A&A...470..475A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2007A%26A...470..475A/gammacat_2007A%26A...470..475A_000048_sed.ecsv"
+    },
+    {
+        "source_id": 48,
+        "reference_id": "['2007A&A...470..475A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000048.yaml"
     },
     {
         "source_id": 49,
@@ -777,11 +1113,39 @@
         "location": "data/2017ApJ...834....2A/gammacat_2017ApJ...834....2A_000049_sed.ecsv"
     },
     {
+        "source_id": 49,
+        "reference_id": "['1996ApJ...460..644S', '1996ApJ...472L...9B', '1999A&A...350..757A', '1999ApJ...526L..81M', '2000PhDT.........6P', '2000AIPC..515..113P', '2002A&A...393...89A', '2003ApJ...598..242A', '2005A&A...437...95A', '2006ApJ...641..740R', '2007ApJ...663..125A', '2009ApJ...691L..13D', '2010A&A...519A..32A', '2010JPhG...37l5201C', '2011ApJ...734..110B', '2011ApJ...738...25A', '2012JPhG...39d5201C', '2015NIMPA.770...42S', '2017ApJ...834....2A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000049.yaml"
+    },
+    {
+        "source_id": 50,
+        "reference_id": "['https://www.mpi-hd.mpg.de/hfm/HESS/pages/home/som/2009/11/', 'http://cxc.harvard.edu/cdo/snr09/pres/DjannatiAtai_Arache_v2.pdf', '2013ApJ...773...77A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000050.yaml"
+    },
+    {
+        "source_id": 51,
+        "reference_id": "['http://www.astronomerstelegram.org/?read=6062']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000051.yaml"
+    },
+    {
         "source_id": 52,
         "reference_id": "2006ApJ...648L.105A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2006ApJ...648L.105A/gammacat_2006ApJ...648L.105A_000052_sed.ecsv"
+    },
+    {
+        "source_id": 52,
+        "reference_id": "['2016PhRvD..93d3011H', '2011arXiv1109.6808R', '2011arXiv1110.6341R', '2006ApJ...648L.105A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000052.yaml"
     },
     {
         "source_id": 53,
@@ -812,6 +1176,13 @@
         "location": "data/2013ApJ...779...92A/gammacat_2013ApJ...779...92A_000053_sed.ecsv"
     },
     {
+        "source_id": 53,
+        "reference_id": "['2011arXiv1110.0038W', '2012AIPC.1505..538P', 'http://www.astronomerstelegram.org/?read=3100', '2012A&A...544A.142A', '2013ApJ...779...92A', '2017ApJ...836..205A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000053.yaml"
+    },
+    {
         "source_id": 54,
         "reference_id": "2008ApJ...684L..73A",
         "file_id": -1,
@@ -840,6 +1211,13 @@
         "location": "data/2009ApJ...707..612A/gammacat_2009ApJ...707..612A_000054_sed.ecsv"
     },
     {
+        "source_id": 54,
+        "reference_id": "['2008ApJ...684L..73A', '2009ApJ...707..612A', '2015arXiv150807347J']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000054.yaml"
+    },
+    {
         "source_id": 55,
         "reference_id": "2009ApJ...695.1370A",
         "file_id": -1,
@@ -854,11 +1232,32 @@
         "location": "data/2010ApJ...709L.163A/gammacat_2010ApJ...709L.163A_000055_sed.ecsv"
     },
     {
+        "source_id": 55,
+        "reference_id": "['2009ApJ...695.1370A', '2010ApJ...709L.163A', '2011arXiv1110.6786L', '2011ICRC....8..151C', '2014ApJ...788..158A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000055.yaml"
+    },
+    {
         "source_id": 56,
         "reference_id": "2011ApJ...730L...8A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2011ApJ...730L...8A/gammacat_2011ApJ...730L...8A_000056_sed.ecsv"
+    },
+    {
+        "source_id": 56,
+        "reference_id": "['http://www.astronomerstelegram.org/?read=5981', 'http://www.astronomerstelegram.org/?read=2684', '2011ApJ...730L...8A', '2015arXiv150103554C']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000056.yaml"
+    },
+    {
+        "source_id": 57,
+        "reference_id": "['http://www.astronomerstelegram.org/?read=5038']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000057.yaml"
     },
     {
         "source_id": 58,
@@ -875,11 +1274,25 @@
         "location": "data/2012ApJ...746..151A/gammacat_2012ApJ...746..151A_000058_lc.ecsv"
     },
     {
+        "source_id": 58,
+        "reference_id": "['2003A&A...403L...1A', '2006Sci...314.1424A', '2008ApJ...679..397A', '2010ApJ...716..819A', '2012A&A...544A..96A', '2012ApJ...746..141A', '2012ApJ...746..151A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000058.yaml"
+    },
+    {
         "source_id": 59,
         "reference_id": "2008Sci...320.1752M",
         "file_id": -1,
         "type": "sed",
         "location": "data/2008Sci...320.1752M/gammacat_2008Sci...320.1752M_000059_sed.ecsv"
+    },
+    {
+        "source_id": 59,
+        "reference_id": "['2008AIPC.1085..423E', '2008Sci...320.1752M', '2011A&A...530A...4A', '2016arXiv161005523C']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000059.yaml"
     },
     {
         "source_id": 60,
@@ -901,6 +1314,13 @@
         "file_id": -1,
         "type": "ds",
         "location": "data/2013A%26A...551A..94H/gammacat_2013A%26A...551A..94H_000060_ds.yaml"
+    },
+    {
+        "source_id": 60,
+        "reference_id": "['2005A&A...442....1A', '2009A&A...507..389A', '2013A&A...551A..94H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000060.yaml"
     },
     {
         "source_id": 61,
@@ -931,11 +1351,32 @@
         "location": "data/2012A%26A...548A..46H/gammacat_2012A%26A...548A..46H_000061_sed.ecsv"
     },
     {
+        "source_id": 61,
+        "reference_id": "['2005A&A...439.1013A', '2012A&A...548A..46H', '2013ApJ...773...77A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000061.yaml"
+    },
+    {
         "source_id": 62,
         "reference_id": "2013MNRAS.434.1889H",
         "file_id": -1,
         "type": "sed",
         "location": "data/2013MNRAS.434.1889H/gammacat_2013MNRAS.434.1889H_000062_sed.ecsv"
+    },
+    {
+        "source_id": 62,
+        "reference_id": "['2011ICRC....8..109C', '2013MNRAS.434.1889H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000062.yaml"
+    },
+    {
+        "source_id": 63,
+        "reference_id": "['2009ApJ...695L..40A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000063.yaml"
     },
     {
         "source_id": 64,
@@ -952,6 +1393,13 @@
         "location": "data/2011A%26A...533A.103H/gammacat_2011A%26A...533A.103H_000064_sed.ecsv"
     },
     {
+        "source_id": 64,
+        "reference_id": "['2008AIPC.1085..285R', '2011A&A...533A.103H', '2013ApJ...773...77A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000064.yaml"
+    },
+    {
         "source_id": 65,
         "reference_id": "2006A&A...456..245A",
         "file_id": -1,
@@ -966,6 +1414,13 @@
         "location": "data/2006A%26A...456..245A/gammacat_2006A%26A...456..245A_000065_sed.ecsv"
     },
     {
+        "source_id": 65,
+        "reference_id": "['2006A&A...456..245A', '2013ApJ...773...77A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000065.yaml"
+    },
+    {
         "source_id": 66,
         "reference_id": "2006A&A...456..245A",
         "file_id": -1,
@@ -978,6 +1433,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2006A%26A...456..245A/gammacat_2006A%26A...456..245A_000066_sed.ecsv"
+    },
+    {
+        "source_id": 66,
+        "reference_id": "['2006A&A...456..245A', '2012A&A...543L...9N', '2012ApJ...750..162K', '2013ApJ...773...77A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000066.yaml"
     },
     {
         "source_id": 67,
@@ -1008,6 +1470,13 @@
         "location": "data/2014ApJ...785L..16A/gammacat_2014ApJ...785L..16A_000067_sed.ecsv"
     },
     {
+        "source_id": 67,
+        "reference_id": "['2010ApJ...708L.100A', '2014ApJ...785L..16A', '2014A&A...567A.135A', '2015arXiv150807251B', '2016A&A...589A..92R']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000067.yaml"
+    },
+    {
         "source_id": 68,
         "reference_id": "2008A&A...477..353A",
         "file_id": -1,
@@ -1022,11 +1491,25 @@
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000068_sed.ecsv"
     },
     {
+        "source_id": 68,
+        "reference_id": "['2008A&A...477..353A', '2011arXiv1111.1634T', '2011ICRC....6..202T', '2013ApJ...773..139V', '2013arXiv1308.1626V', '2013PASJ...65...61F', '2016arXiv160901125G']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000068.yaml"
+    },
+    {
         "source_id": 69,
         "reference_id": "2003A&A...403..523A",
         "file_id": 2,
         "type": "sed",
         "location": "data/2003A%26A...403..523A/gammacat_2003A%26A...403..523A_000069_sed.ecsv"
+    },
+    {
+        "source_id": 69,
+        "reference_id": "['2002ApJ...571..753H', '2002A&A...384L..23A', '2003A&A...403..523A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000069.yaml"
     },
     {
         "source_id": 70,
@@ -1043,6 +1526,13 @@
         "location": "data/2016arXiv160104461H/gammacat_2016arXiv160104461H_000070_sed.ecsv"
     },
     {
+        "source_id": 70,
+        "reference_id": "['2009Sci...325..719H', '2009ApJ...692.1500A', '2011ApJ...741...96W', '2014A&A...562A.141M', '2015APh....65...80M', '2016arXiv160104461H', '2016arXiv160106534T']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000070.yaml"
+    },
+    {
         "source_id": 71,
         "reference_id": "2016MNRAS.461..202A",
         "file_id": -1,
@@ -1055,6 +1545,27 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2016MNRAS.461..202A/gammacat_2016MNRAS.461..202A_000071_sed.ecsv"
+    },
+    {
+        "source_id": 71,
+        "reference_id": "['http://www.astronomerstelegram.org/?read=2786', '2011arXiv1110.0040W', '2011ICRC....8...43M', '2015arXiv150103554C', '2016MNRAS.461..202A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000071.yaml"
+    },
+    {
+        "source_id": 72,
+        "reference_id": "['2010tsra.confE.196H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000072.yaml"
+    },
+    {
+        "source_id": 73,
+        "reference_id": "['2011ICRC....7..158G', '2012arXiv1205.0719D', '2013ApJ...773...77A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000073.yaml"
     },
     {
         "source_id": 74,
@@ -1071,6 +1582,13 @@
         "location": "data/2010A%26A...516A..62A/gammacat_2010A%26A...516A..62A_000074_sed.ecsv"
     },
     {
+        "source_id": 74,
+        "reference_id": "['2010A&A...516A..62A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000074.yaml"
+    },
+    {
         "source_id": 75,
         "reference_id": "2008AIPC.1085..281R",
         "file_id": -1,
@@ -1083,6 +1601,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2008AIPC.1085..281R/gammacat_2008AIPC.1085..281R_000075_sed.ecsv"
+    },
+    {
+        "source_id": 75,
+        "reference_id": "['2008AIPC.1085..281R']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000075.yaml"
     },
     {
         "source_id": 77,
@@ -1099,6 +1624,13 @@
         "location": "data/2011A%26A...525A..45H/gammacat_2011A%26A...525A..45H_000077_sed.ecsv"
     },
     {
+        "source_id": 77,
+        "reference_id": "['2009arXiv0912.4229T', '2011AdSpR..47..640D', '2011arXiv1111.1634T', '2011ICRC....6..202T', '2011A&A...525A..45H', '2012A&A...545A..94D', '2013ApJ...773..139V', '2013arXiv1308.1626V', '2013ApJ...773...77A', '2015MNRAS.447.3564E']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000077.yaml"
+    },
+    {
         "source_id": 78,
         "reference_id": "2013A&A...554A.107H",
         "file_id": -1,
@@ -1106,11 +1638,25 @@
         "location": "data/2013A%26A...554A.107H/gammacat_2013A%26A...554A.107H_000078_sed.ecsv"
     },
     {
+        "source_id": 78,
+        "reference_id": "['2013A&A...554A.107H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000078.yaml"
+    },
+    {
         "source_id": 79,
         "reference_id": "2005A&A...435L..17A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2005A%26A...435L..17A/gammacat_2005A%26A...435L..17A_000079_sed.ecsv"
+    },
+    {
+        "source_id": 79,
+        "reference_id": "['2005A&A...435L..17A', '2013ApJ...773...77A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000079.yaml"
     },
     {
         "source_id": 80,
@@ -1127,6 +1673,13 @@
         "location": "data/2015A%26A...573A..31H/gammacat_2015A%26A...573A..31H_000080_sed.ecsv"
     },
     {
+        "source_id": 80,
+        "reference_id": "['2015A&A...573A..31H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000080.yaml"
+    },
+    {
         "source_id": 81,
         "reference_id": "2011ICRC....7..185A",
         "file_id": -1,
@@ -1139,6 +1692,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2011ICRC....7..185A/gammacat_2011ICRC....7..185A_000081_sed.ecsv"
+    },
+    {
+        "source_id": 81,
+        "reference_id": "['2011ICRC....7..185A', '2016ApJ...820..100M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000081.yaml"
     },
     {
         "source_id": 82,
@@ -1169,6 +1729,13 @@
         "location": "data/2015ApJ...802...65A/gammacat_2015ApJ...802...65A_000082_sed.ecsv"
     },
     {
+        "source_id": 82,
+        "reference_id": "['2008A&A...477..481A', '2012ApJ...748...46A', '2015ApJ...802...65A', '2015ApJ...799....7A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000082.yaml"
+    },
+    {
         "source_id": 83,
         "reference_id": "2006ApJ...636..777A",
         "file_id": -1,
@@ -1181,6 +1748,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000083_sed.ecsv"
+    },
+    {
+        "source_id": 83,
+        "reference_id": "['2005Sci...307.1938A', '2006ApJ...636..777A', '2008PASJ...60S.163M', '2008AIPC.1085..241R', '2010ASPC..422..265O', '2011PASJ...63S.879S', '2013ApJ...773...77A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000083.yaml"
     },
     {
         "source_id": 84,
@@ -1197,6 +1771,13 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000084_sed.ecsv"
     },
     {
+        "source_id": 84,
+        "reference_id": "['2005Sci...307.1938A', '2006ApJ...636..777A', '2007MNRAS.380..926L', '2009ApJ...690..891K', '2011ICRC....6..202T', '2011arXiv1111.1634T', '2013ApJ...773...77A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000084.yaml"
+    },
+    {
         "source_id": 85,
         "reference_id": "2008A&A...477..353A",
         "file_id": -1,
@@ -1209,6 +1790,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000085_sed.ecsv"
+    },
+    {
+        "source_id": 85,
+        "reference_id": "['2008A&A...477..353A', '2011arXiv1110.1252E', '2013ApJ...773...77A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000085.yaml"
     },
     {
         "source_id": 86,
@@ -1225,6 +1813,13 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000086_sed.ecsv"
     },
     {
+        "source_id": 86,
+        "reference_id": "['2006ApJ...636..777A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000086.yaml"
+    },
+    {
         "source_id": 87,
         "reference_id": "2006ApJ...636..777A",
         "file_id": -1,
@@ -1237,6 +1832,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000087_sed.ecsv"
+    },
+    {
+        "source_id": 87,
+        "reference_id": "['2006ApJ...636..777A', '2013ApJ...773...77A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000087.yaml"
     },
     {
         "source_id": 88,
@@ -1260,6 +1862,13 @@
         "location": "data/2014MNRAS.439.2828A/gammacat_2014MNRAS.439.2828A_000088_sed.ecsv"
     },
     {
+        "source_id": 88,
+        "reference_id": "['2006ApJ...636..777A', '2014MNRAS.439.2828A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000088.yaml"
+    },
+    {
         "source_id": 89,
         "reference_id": "2014ApJ...794L...1A",
         "file_id": -1,
@@ -1274,11 +1883,25 @@
         "location": "data/2014ApJ...794L...1A/gammacat_2014ApJ...794L...1A_000089_sed.ecsv"
     },
     {
+        "source_id": 89,
+        "reference_id": "['2013arXiv1303.0979O', '2014ApJ...794L..16L', '2014ApJ...794L...1A', '2015ApJ...812...32T', '2015arXiv150908310O', '2016arXiv161005444L']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000089.yaml"
+    },
+    {
         "source_id": 90,
         "reference_id": "2012A&A...537A.114A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2012A%26A...537A.114A/gammacat_2012A%26A...537A.114A_000090_sed.ecsv"
+    },
+    {
+        "source_id": 90,
+        "reference_id": "['2010ASPC..422..265O', '2010ApJ...713L..45L', '2012A&A...537A.114A', '2013MNRAS.434.2289O', '2013PASJ...65...64S']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000090.yaml"
     },
     {
         "source_id": 91,
@@ -1323,6 +1946,13 @@
         "location": "data/2012ApJ...758....2B/gammacat_2012ApJ...758....2B_000091_sed.ecsv"
     },
     {
+        "source_id": 91,
+        "reference_id": "['1996ApJ...456L..83Q', '1999A&A...342...69A', '2001ApJ...546..898A', '2001A&A...366...62A', '2008JPhG...35f5202G', '2009ApJ...705.1624A', '2011ApJ...727..129A', '2011ApJ...729....2A', '2012ApJ...758....2B', '2015A&A...573A..50A', '2015ApJ...812...65F', '2017A%26A...603A..31A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000091.yaml"
+    },
+    {
         "source_id": 92,
         "reference_id": "2006ApJ...636..777A",
         "file_id": -1,
@@ -1349,6 +1979,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000092_sed.ecsv"
+    },
+    {
+        "source_id": 92,
+        "reference_id": "['2006ApJ...636..777A', '2008A&A...477..353A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000092.yaml"
     },
     {
         "source_id": 93,
@@ -1379,11 +2016,25 @@
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000093_sed.ecsv"
     },
     {
+        "source_id": 93,
+        "reference_id": "['2006ApJ...636..777A', '2008A&A...477..353A', '2009ApJ...707.1717V', '2011ICRC....6..202T', '2011arXiv1111.1634T']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000093.yaml"
+    },
+    {
         "source_id": 94,
         "reference_id": "2011A&A...528A.143H",
         "file_id": -1,
         "type": "sed",
         "location": "data/2011A%26A...528A.143H/gammacat_2011A%26A...528A.143H_000094_sed.ecsv"
+    },
+    {
+        "source_id": 94,
+        "reference_id": "['2009ApJ...703.1725E', '2009ApJ...702..631Y', '2009arXiv0906.5574H', '2011A&A...528A.143H', '2013ApJ...773...77A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000094.yaml"
     },
     {
         "source_id": 95,
@@ -1414,6 +2065,13 @@
         "location": "data/2008A%26A...486..829A/gammacat_2008A%26A...486..829A_000095_sed.ecsv"
     },
     {
+        "source_id": 95,
+        "reference_id": "['2006ApJ...636..777A', '2008A&A...486..829A', '2010ApJ...710..941H', '2010ApJ...725.1384H', '2011RAA....11..625H', '2012MNRAS.421.2593T', '2013MNRAS.434.2748C', '2015APh....65...80M', '2016ApJ...817...64X']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000095.yaml"
+    },
+    {
         "source_id": 96,
         "reference_id": "2004Natur.432...75A",
         "file_id": -1,
@@ -1435,11 +2093,25 @@
         "location": "data/2016arXiv160908671H/gammacat_2016arXiv160908671H_000096_sed.ecsv"
     },
     {
+        "source_id": 96,
+        "reference_id": "['2004Natur.432...75A', '2006A&A...449..223A', '2007A&A...464..235A', '2016arXiv160908671H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000096.yaml"
+    },
+    {
         "source_id": 97,
         "reference_id": "2008A&A...490..685A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2008A%26A...490..685A/gammacat_2008A%26A...490..685A_000097_sed.ecsv"
+    },
+    {
+        "source_id": 97,
+        "reference_id": "['2008A&A...490..685A', '2010ApJ...717..372C', '2012MNRAS.421..935L', '2012ApJ...761..133Y', '2012MNRAS.421.2593T', '2013A&A...553A..34D', '2013MNRAS.434.2188M', '2013AdSpR..51..247B']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000097.yaml"
     },
     {
         "source_id": 98,
@@ -1456,11 +2128,32 @@
         "location": "data/2015A%26A...574A.100H/gammacat_2015A%26A...574A.100H_000098_sed.ecsv"
     },
     {
+        "source_id": 98,
+        "reference_id": "['2015A&A...574A.100H', '2014ApJ...783L...2T', '2015ApJ...804..124E']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000098.yaml"
+    },
+    {
         "source_id": 99,
         "reference_id": "2007A&A...472..489A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2007A%26A...472..489A/gammacat_2007A%26A...472..489A_000099_sed.ecsv"
+    },
+    {
+        "source_id": 99,
+        "reference_id": "['2007A&A...476L..25H', '2007A&A...472..489A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000099.yaml"
+    },
+    {
+        "source_id": 100,
+        "reference_id": "['http://www.astronomerstelegram.org/?read=5080', '2016arXiv160306523A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000100.yaml"
     },
     {
         "source_id": 101,
@@ -1484,11 +2177,25 @@
         "location": "data/2015ApJ...808..110A/gammacat_2015ApJ...808..110A_000101_sed.ecsv"
     },
     {
+        "source_id": 101,
+        "reference_id": "['http://www.astronomerstelegram.org/?read=3774', '2013arXiv1308.0287D', '2014A&A...563A..90A', '2015arXiv150805551C', '2015arXiv150807251B', '2015ApJ...808..110A', '2015arXiv150103554C', '2015ApJ...808..110A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000101.yaml"
+    },
+    {
         "source_id": 102,
         "reference_id": "2011A&A...531A..81H",
         "file_id": -1,
         "type": "sed",
         "location": "data/2011A%26A...531A..81H/gammacat_2011A%26A...531A..81H_000102_sed.ecsv"
+    },
+    {
+        "source_id": 102,
+        "reference_id": "['2011A&A...531A..81H', '2015arXiv150306717M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000102.yaml"
     },
     {
         "source_id": 103,
@@ -1512,6 +2219,20 @@
         "location": "data/2011A%26A...531A..81H/gammacat_2011A%26A...531A..81H_000103_sed.ecsv"
     },
     {
+        "source_id": 103,
+        "reference_id": "['2008ApJ...679L..85T', '2008A&A...477..353A', '2010ApJ...710..941H', '2010ApJ...712..790T', '2011A&A...531A..81H', '2012ApJ...756..149B', '2013A&A...556A..41K', '2013MNRAS.434.2748C', '2015A&A...573A..53K', '2015MNRAS.454.2668O', '2015A&A...580A..74A', '2015arXiv150306717M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000103.yaml"
+    },
+    {
+        "source_id": 104,
+        "reference_id": "['2008AIPC.1085..249T', '2016ApJ...816...52H', '2016MNRAS.tmp....7H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000104.yaml"
+    },
+    {
         "source_id": 105,
         "reference_id": "2016MNRAS.459.2550A",
         "file_id": -1,
@@ -1531,6 +2252,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2016MNRAS.459.2550A/gammacat_2016MNRAS.459.2550A_000105_sed.ecsv"
+    },
+    {
+        "source_id": 105,
+        "reference_id": "['2011ICRC....8..169B', '2013arXiv1308.0287D', '2016MNRAS.459.2550A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000105.yaml"
     },
     {
         "source_id": 106,
@@ -1575,6 +2303,20 @@
         "location": "data/2016Natur.531..476H/gammacat_2016Natur.531..476H_000106_sed.ecsv"
     },
     {
+        "source_id": 106,
+        "reference_id": "['2004A&A...425L..13A', '2006PhRvL..97v1102A', '2009A&A...503..817A', '2010MNRAS.402.1877A', '2014ApJ...790..149A', '2015arXiv150903425P', '2015arXiv150806311S', '2016Natur.531..476H', '2016ApJ...821..129A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000106.yaml"
+    },
+    {
+        "source_id": 107,
+        "reference_id": "['2006Natur.439..695A', '2010MNRAS.402.1877A', '2016ApJ...821..129A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000107.yaml"
+    },
+    {
         "source_id": 108,
         "reference_id": "2006ApJ...636..777A",
         "file_id": -1,
@@ -1594,6 +2336,20 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2008A%26A...483..509A/gammacat_2008A%26A...483..509A_000108_sed.ecsv"
+    },
+    {
+        "source_id": 108,
+        "reference_id": "['2006ApJ...636..777A', '2008A&A...483..509A', '2009ApJ...691.1854B', '2011arXiv1111.1634T', '2011ICRC....6..202T', '2011ApJ...735..115H', '2012AIPC.1505..265E', '2012ApJ...761..133Y', '2015APh....65...80M', '2016MNRAS.457.4262H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000108.yaml"
+    },
+    {
+        "source_id": 109,
+        "reference_id": "['2006ApJ...636..777A', '2011A&A...531L..18H', '2011ICRC....7..119D', '2011A&A...533L...5D', '2013A&A...551A..26H', '2013MmSAI..84..236M', '2013MNRAS.432.3462Z', '2014MNRAS.445.2842B']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000109.yaml"
     },
     {
         "source_id": 110,
@@ -1617,6 +2373,20 @@
         "location": "data/2016ApJ...821..129A/gammacat_2016ApJ...821..129A_000110_sed.ecsv"
     },
     {
+        "source_id": 110,
+        "reference_id": "['1987ApJ...314..203H', '2005A&A...432L..25A', '2008A&A...487.1033D', '2010A&A...515A..20F', '2015arXiv150806311S', '2016ApJ...821..129A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000110.yaml"
+    },
+    {
+        "source_id": 111,
+        "reference_id": "['2008A&A...481..401A', '2010ApJ...718..348A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000111.yaml"
+    },
+    {
         "source_id": 112,
         "reference_id": "2008A&A...481..401A",
         "file_id": -1,
@@ -1629,6 +2399,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2008A%26A...481..401A/gammacat_2008A%26A...481..401A_000112_sed.ecsv"
+    },
+    {
+        "source_id": 112,
+        "reference_id": "['1997ApJ...489..143C', '2004ASPC..317...59M', '2008AIPC.1085..104F', '2008A&A...481..401A', '2009ApJ...707L.179F', '2010MNRAS.407...94M', '2010ApJ...718..348A', '2010A&A...516L..11G', '2012MNRAS.421..935L', '2012A&A...543L...9N', '2012ApJ...761..133Y', '2013MNRAS.429.1643N', '2013A&A...553A..34D', '2015APh....65...80M', '2015arXiv150306580G', '2016arXiv161000865M', '2016MNRAS.462..532M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000112.yaml"
     },
     {
         "source_id": 113,
@@ -1645,6 +2422,13 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000113_sed.ecsv"
     },
     {
+        "source_id": 113,
+        "reference_id": "['2005Sci...307.1938A', '2006ApJ...636..777A', '2008ApJ...683..957H', '2010ApJ...717..372C', '2012ApJ...744...80A', '2012ApJ...761..133Y', '2013ApJ...773...77A', '2013ApJ...766...29L', '2015APh....65...80M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000113.yaml"
+    },
+    {
         "source_id": 114,
         "reference_id": "2016arXiv160605404A",
         "file_id": -1,
@@ -1659,11 +2443,25 @@
         "location": "data/2016arXiv160605404A/gammacat_2016arXiv160605404A_000114_sed.ecsv"
     },
     {
+        "source_id": 114,
+        "reference_id": "['https://www.mpi-hd.mpg.de/hd2012/pages/presentations/Rowell.pdf', '2016arXiv160605404A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000114.yaml"
+    },
+    {
         "source_id": 115,
         "reference_id": "2007A&A...472..489A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2007A%26A...472..489A/gammacat_2007A%26A...472..489A_000115_sed.ecsv"
+    },
+    {
+        "source_id": 115,
+        "reference_id": "['2007A&A...472..489A', '2008AIPC.1085..285R', '2010PASJ...62..179A', '2014ApJ...796...34R', '2016A&A...587A..71C']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000115.yaml"
     },
     {
         "source_id": 116,
@@ -1680,11 +2478,25 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000116_sed.ecsv"
     },
     {
+        "source_id": 116,
+        "reference_id": "['2005Sci...307.1938A', '2006ApJ...637L..41A', '2006ApJ...636..777A', '2007A&A...470..249F', '2008ApJ...683L.155M', '2008A&A...485..195D', '2009ApJ...700L.158G', '2010ApJ...718..467F', '2012ApJ...753L..14H', '2013ApJ...773...77A', '2015APh....65...80M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000116.yaml"
+    },
+    {
         "source_id": 117,
         "reference_id": "2014A&A...562A..40H",
         "file_id": -1,
         "type": "sed",
         "location": "data/2014A%26A...562A..40H/gammacat_2014A%26A...562A..40H_000117_sed.ecsv"
+    },
+    {
+        "source_id": 117,
+        "reference_id": "['2011ICRC....7..248H', '2013A&A...557L..15C', '2014A&A...562A..40H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000117.yaml"
     },
     {
         "source_id": 118,
@@ -1722,6 +2534,13 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000118_sed.ecsv"
     },
     {
+        "source_id": 118,
+        "reference_id": "['2005Sci...307.1938A', '2005A&A...442L..25A', '2006ApJ...636..777A', '2006A&A...460..365A', '2008ApJ...675..683P', '2009PASJ...61S.189U', '2011ApJ...738...42G', '2011ApJ...742...62V', '2012arXiv1202.1455M', '2013ApJ...773...77A', '2016ApJ...817....3A', '2016MNRAS.458.2813V']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000118.yaml"
+    },
+    {
         "source_id": 119,
         "reference_id": "2005Sci...309..746A",
         "file_id": -1,
@@ -1750,6 +2569,13 @@
         "location": "data/2006A%26A...460..743A/gammacat_2006A%26A...460..743A_000119_sed.ecsv"
     },
     {
+        "source_id": 119,
+        "reference_id": "['2005Sci...309..746A', '2006A&A...460..743A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000119.yaml"
+    },
+    {
         "source_id": 120,
         "reference_id": "2011ICRC....7..244S",
         "file_id": -1,
@@ -1764,11 +2590,32 @@
         "location": "data/2011ICRC....7..244S/gammacat_2011ICRC....7..244S_000120_sed.ecsv"
     },
     {
+        "source_id": 120,
+        "reference_id": "['2011ICRC....7..244S']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000120.yaml"
+    },
+    {
         "source_id": 121,
         "reference_id": "2015MNRAS.446.1163H",
         "file_id": -1,
         "type": "sed",
         "location": "data/2015MNRAS.446.1163H/gammacat_2015MNRAS.446.1163H_000121_sed.ecsv"
+    },
+    {
+        "source_id": 121,
+        "reference_id": "['2011arXiv1110.6890L', '2013arXiv1308.0475L', '2015MNRAS.446.1163H', '2016arXiv161003264B', '2016MNRAS.457.1753E']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000121.yaml"
+    },
+    {
+        "source_id": 122,
+        "reference_id": "['2008ICRC....2..823D', '2008MNRAS.391L..54T', '2009MNRAS.393..527D', '2011MNRAS.412.1221B', '2012ASPC..466..167K', '2016MNRAS.460.4135P', 'https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000122.yaml"
     },
     {
         "source_id": 123,
@@ -1785,6 +2632,13 @@
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000123_sed.ecsv"
     },
     {
+        "source_id": 123,
+        "reference_id": "['2005Sci...307.1938A', '2006ApJ...643L..53A', '2006ApJ...636..777A', '2007ApJ...657L..25T', '2009ApJ...691.1707M', '2010cosp...38.2801M', '2011ApJ...735...33M', '2012MNRAS.421..935L', '2012ApJ...761..133Y', '2013ApJ...773L..19F', '2013ApJ...773...77A', '2015APh....65...80M', '2016ApJ...817....3A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000123.yaml"
+    },
+    {
         "source_id": 124,
         "reference_id": "2006ApJ...636..777A",
         "file_id": -1,
@@ -1797,6 +2651,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2006ApJ...636..777A/gammacat_2006ApJ...636..777A_000124_sed.ecsv"
+    },
+    {
+        "source_id": 124,
+        "reference_id": "['2005Sci...307.1938A', '2006ApJ...636..777A', '2008ApJ...681..515G', '2009PASJ...61S.183A', '2012arXiv1202.1455M', '2013ApJ...773...77A', '2014PASJ...66...19F', '2016ApJ...817....3A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000124.yaml"
     },
     {
         "source_id": 125,
@@ -1813,11 +2674,46 @@
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000125_sed.ecsv"
     },
     {
+        "source_id": 125,
+        "reference_id": "['2008A&A...477..353A', '2009ApJ...697.1194S', '2011arXiv1111.1634T', '2011ICRC....6..202T', '2013ApJ...779...27B', '2013ApJ...773...77A', '2013arXiv1303.1258T', '2015AdSpR..55.2493N', '2016ApJ...817....3A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000125.yaml"
+    },
+    {
+        "source_id": 126,
+        "reference_id": "['2008ICRC....2..579H', '2013ApJ...779...27B', '2016ApJ...817....3A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000126.yaml"
+    },
+    {
+        "source_id": 127,
+        "reference_id": "['2008ICRC....2..823D', '2008A&A...480L..25L', '2016ApJ...817....3A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000127.yaml"
+    },
+    {
         "source_id": 128,
         "reference_id": "2008AIPC.1085..372C",
         "file_id": -1,
         "type": "sed",
         "location": "data/2008AIPC.1085..372C/gammacat_2008AIPC.1085..372C_000128_sed.ecsv"
+    },
+    {
+        "source_id": 128,
+        "reference_id": "['2008AIPC.1085..372C', '2011MmSAI..82..739L', '2013ApJ...773...77A', '2016ApJ...817....3A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000128.yaml"
+    },
+    {
+        "source_id": 129,
+        "reference_id": "['http://www.astronomerstelegram.org/?read=3057', '2011ApJ...729L..16G', '2015APh....65...80M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000129.yaml"
     },
     {
         "source_id": 130,
@@ -1834,6 +2730,13 @@
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000130_sed.ecsv"
     },
     {
+        "source_id": 130,
+        "reference_id": "['2008A&A...477..353A', '2014A&A...571A..96M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000130.yaml"
+    },
+    {
         "source_id": 131,
         "reference_id": "2008A&A...477..353A",
         "file_id": -1,
@@ -1846,6 +2749,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2008A%26A...477..353A/gammacat_2008A%26A...477..353A_000131_sed.ecsv"
+    },
+    {
+        "source_id": 131,
+        "reference_id": "['2008A&A...477..353A', '2016ApJ...817....3A', '2014ApJ...787..166A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000131.yaml"
     },
     {
         "source_id": 132,
@@ -1869,6 +2779,13 @@
         "location": "data/2014ApJ...787..166A/gammacat_2014ApJ...787..166A_000132_sed.ecsv"
     },
     {
+        "source_id": 132,
+        "reference_id": "['2007arXiv0710.4057T', '2009A&A...499..723A', '2014ApJ...787..166A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000132.yaml"
+    },
+    {
         "source_id": 133,
         "reference_id": "2016arXiv160900600H",
         "file_id": -1,
@@ -1881,6 +2798,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2016arXiv160900600H/gammacat_2016arXiv160900600H_000133_sed.ecsv"
+    },
+    {
+        "source_id": 133,
+        "reference_id": "['2011arXiv1104.5003B', '2011ICRC....7..111B', '2016arXiv160900600H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000133.yaml"
     },
     {
         "source_id": 134,
@@ -1897,6 +2821,20 @@
         "location": "data/2008A%26A...484..435A/gammacat_2008A%26A...484..435A_000134_sed.ecsv"
     },
     {
+        "source_id": 134,
+        "reference_id": "['2008A&A...484..435A', '2016arXiv161200261G']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000134.yaml"
+    },
+    {
+        "source_id": 135,
+        "reference_id": "['2012A&A...541A..13A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000135.yaml"
+    },
+    {
         "source_id": 136,
         "reference_id": "2010ApJ...719L..69A",
         "file_id": -1,
@@ -1909,6 +2847,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2010ApJ...719L..69A/gammacat_2010ApJ...719L..69A_000136_sed.ecsv"
+    },
+    {
+        "source_id": 136,
+        "reference_id": "['2010ApJ...719L..69A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000136.yaml"
     },
     {
         "source_id": 137,
@@ -1930,6 +2875,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2016arXiv161005799S/gammacat_2016arXiv161005799S_000137_sed.ecsv"
+    },
+    {
+        "source_id": 137,
+        "reference_id": "['2011A&A...529A..49H', '2016arXiv161005799S']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000137.yaml"
     },
     {
         "source_id": 138,
@@ -1981,11 +2933,32 @@
         "location": "data/2013ApJ...775....3A/gammacat_2013ApJ...775....3A_000138_sed.ecsv"
     },
     {
+        "source_id": 138,
+        "reference_id": "['2003ApJ...583L...9H', '2003ICRC....5.2615T', '2003A&A...406L...9A', '2005ApJ...621..181D', '2006ApJ...639..761A', '2008ApJ...679.1029T', '2013ApJ...775....3A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000138.yaml"
+    },
+    {
+        "source_id": 139,
+        "reference_id": "['2010ATel.2753....1M']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000139.yaml"
+    },
+    {
         "source_id": 140,
         "reference_id": "2010A&A...511A..52H",
         "file_id": -1,
         "type": "sed",
         "location": "data/2010A%26A...511A..52H/gammacat_2010A%26A...511A..52H_000140_sed.ecsv"
+    },
+    {
+        "source_id": 140,
+        "reference_id": "['2005A&A...436L..17A', '2010A&A...511A..52H', '2011A&A...533A.110H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000140.yaml"
     },
     {
         "source_id": 141,
@@ -2002,6 +2975,20 @@
         "location": "data/2014ApJ...788...78A/gammacat_2014ApJ...788...78A_000141_sed.ecsv"
     },
     {
+        "source_id": 141,
+        "reference_id": "['2014ApJ...788...78A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000141.yaml"
+    },
+    {
+        "source_id": 142,
+        "reference_id": "['2012ApJ...753..159A', '2007ApJ...658L..33A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000142.yaml"
+    },
+    {
         "source_id": 143,
         "reference_id": "2014ApJ...788...78A",
         "file_id": -1,
@@ -2014,6 +3001,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2014ApJ...788...78A/gammacat_2014ApJ...788...78A_000143_sed.ecsv"
+    },
+    {
+        "source_id": 143,
+        "reference_id": "['2012ApJ...753..159A', '2014ApJ...788...78A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000143.yaml"
     },
     {
         "source_id": 144,
@@ -2030,6 +3024,20 @@
         "location": "data/2013ApJ...770...93A/gammacat_2013ApJ...770...93A_000144_sed.ecsv"
     },
     {
+        "source_id": 144,
+        "reference_id": "['2013ApJ...770...93A', '2011arXiv1111.1034A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000144.yaml"
+    },
+    {
+        "source_id": 145,
+        "reference_id": "['2009ApJ...700L.127A', '2007AIPC..921..172L']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000145.yaml"
+    },
+    {
         "source_id": 146,
         "reference_id": "2014ApJ...783...16A",
         "file_id": -1,
@@ -2042,6 +3050,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2014ApJ...783...16A/gammacat_2014ApJ...783...16A_000146_sed.ecsv"
+    },
+    {
+        "source_id": 146,
+        "reference_id": "['2014ApJ...783...16A', '2008ApJ...675L..25A', '2003ICRC....4.2345R', '2012ApJ...753..159A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000146.yaml"
     },
     {
         "source_id": 147,
@@ -2093,6 +3108,13 @@
         "location": "data/2013PhRvD..88j2003A/gammacat_2013PhRvD..88j2003A_000147_sed.ecsv"
     },
     {
+        "source_id": 147,
+        "reference_id": "['2005A&A...442..895A', '2005A&A...430..865A', '2009ApJ...696L.150A', '2010A&A...520A..83H', '2012A&A...539A.149H', '2012A&A...544A..75A', '2013PhRvD..88j2003A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000147.yaml"
+    },
+    {
         "source_id": 148,
         "reference_id": "2007ApJ...666L..17A",
         "file_id": -1,
@@ -2121,6 +3143,13 @@
         "location": "data/2013ApJ...762...92A/gammacat_2013ApJ...762...92A_000148_sed.ecsv"
     },
     {
+        "source_id": 148,
+        "reference_id": "['2007ApJ...666L..17A', '2013ApJ...762...92A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000148.yaml"
+    },
+    {
         "source_id": 149,
         "reference_id": "2009ApJ...703L...6A",
         "file_id": -1,
@@ -2135,11 +3164,39 @@
         "location": "data/2009ApJ...703L...6A/gammacat_2009ApJ...703L...6A_000149_sed.ecsv"
     },
     {
+        "source_id": 149,
+        "reference_id": "['2009ApJ...703L...6A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000149.yaml"
+    },
+    {
+        "source_id": 150,
+        "reference_id": "['2009ApJ...700L.127A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000150.yaml"
+    },
+    {
+        "source_id": 151,
+        "reference_id": "['2015arXiv150806334A', '2014ATel.6849....1H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000151.yaml"
+    },
+    {
         "source_id": 152,
         "reference_id": "2012A&A...539A.118A",
         "file_id": -1,
         "type": "sed",
         "location": "data/2012A%26A...539A.118A/gammacat_2012A%26A...539A.118A_000152_sed.ecsv"
+    },
+    {
+        "source_id": 152,
+        "reference_id": "['2012A&A...539A.118A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000152.yaml"
     },
     {
         "source_id": 153,
@@ -2154,6 +3211,13 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2010ApJ...714..163A/gammacat_2010ApJ...714..163A_000153_sed.ecsv"
+    },
+    {
+        "source_id": 153,
+        "reference_id": "['2010ApJ...714..163A', '2001A&A...370..112A', '2015arXiv151100309G']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000153.yaml"
     },
     {
         "source_id": 154,
@@ -2184,11 +3248,25 @@
         "location": "data/2013A%26A...556A..67A/gammacat_2013A%26A...556A..67A_000154_sed.ecsv"
     },
     {
+        "source_id": 154,
+        "reference_id": "['1998ApJ...501..616C', '2005ApJ...634..947S', '2007ApJ...662..892A', '2011ApJ...738..169A', '2013A&A...556A..67A', '2017MNRAS.471.2117A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000154.yaml"
+    },
+    {
         "source_id": 155,
         "reference_id": "2010A&A...516A..56H",
         "file_id": 3,
         "type": "sed",
         "location": "data/2010A%26A...516A..56H/gammacat_2010A%26A...516A..56H_000155_sed.ecsv"
+    },
+    {
+        "source_id": 155,
+        "reference_id": "['2010A&A...516A..56H', '2006A&A...455..461A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000155.yaml"
     },
     {
         "source_id": 156,
@@ -2205,6 +3283,41 @@
         "location": "data/2008A%26A...481..401A/gammacat_2008A%26A...481..401A_000156_sed.ecsv"
     },
     {
+        "source_id": 156,
+        "reference_id": "['2008A&A...481..401A', '2016JHEAp..11....1H']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000156.yaml"
+    },
+    {
+        "source_id": 157,
+        "reference_id": "['2011ICRC....7...76K', '2016ApJ...818...63B']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000157.yaml"
+    },
+    {
+        "source_id": 158,
+        "reference_id": "['2015arXiv150903872P']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000158.yaml"
+    },
+    {
+        "source_id": 159,
+        "reference_id": "['2015arXiv151004518L', '2015arXiv150806311S']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000159.yaml"
+    },
+    {
+        "source_id": 160,
+        "reference_id": "['2015arXiv151004518L', '2015arXiv150806311S']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000160.yaml"
+    },
+    {
         "source_id": 161,
         "reference_id": "2017arXiv170107002A",
         "file_id": -1,
@@ -2212,11 +3325,53 @@
         "location": "data/2017arXiv170107002A/gammacat_2017arXiv170107002A_000161_sed.ecsv"
     },
     {
+        "source_id": 161,
+        "reference_id": "['https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf', '2016MNRAS.458.2813V', '2017arXiv170107002A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000161.yaml"
+    },
+    {
+        "source_id": 162,
+        "reference_id": "['https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000162.yaml"
+    },
+    {
+        "source_id": 163,
+        "reference_id": "['https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000163.yaml"
+    },
+    {
+        "source_id": 164,
+        "reference_id": "['https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000164.yaml"
+    },
+    {
         "source_id": 165,
         "reference_id": "2016ApJ...821..129A",
         "file_id": -1,
         "type": "ds",
         "location": "data/2016ApJ...821..129A/gammacat_2016ApJ...821..129A_000165_ds.yaml"
+    },
+    {
+        "source_id": 165,
+        "reference_id": "['2016ApJ...821..129A', '2017A&A...601A..33A', '2015ICRC...34..838L']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000165.yaml"
+    },
+    {
+        "source_id": 166,
+        "reference_id": "['2008Sci...322.1221A', '2011Sci...334...69V', '2011ApJ...742...43A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000166.yaml"
     },
     {
         "source_id": 167,
@@ -2238,5 +3393,12 @@
         "file_id": -1,
         "type": "sed",
         "location": "data/2015ApJ...815L..22A/gammacat_2015ApJ...815L..22A_000167_sed.ecsv"
+    },
+    {
+        "source_id": 167,
+        "reference_id": "['2015ApJ...815L..23A', '2015ApJ...815L..22A']",
+        "file_id": -1,
+        "type": "bsi",
+        "location": "sources/tev-000167.yaml"
     }
 ]

--- a/docs/data/sources/tev-000001.yaml
+++ b/docs/data/sources/tev-000001.yaml
@@ -1,0 +1,29 @@
+source_id: 1
+
+common_name: CTA 1
+gamma_names:
+- VER J0006+729
+other_names:
+- SNR G119.5+10.2
+
+where: gal
+classes: [pwn, snr]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2011-10
+
+tevcat_id: 227
+tevcat2_id: rC5JCj
+tevcat_name: TeV J0006+729
+
+tgevcat_id: 1
+tgevcat_name: TeV J0006+7259
+
+reference_ids:
+- 2013ApJ...764...38A
+
+pos:
+  simbad_id: CTA 1
+  ra: 1.6500000
+  dec: 72.7830000

--- a/docs/data/sources/tev-000002.yaml
+++ b/docs/data/sources/tev-000002.yaml
@@ -1,0 +1,27 @@
+source_id: 2
+
+common_name: SHBL J001355.9-185406
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2010-11
+
+tevcat_id: 213
+tevcat2_id: 70hRXZ
+tevcat_name: TeV J0013-188
+
+tgevcat_id: 2
+tgevcat_name: TeV J0013-1853
+
+reference_ids:
+- 2013A&A...554A..72H
+
+pos:
+  simbad_id: SHBL J001355.9-185406
+  ra: 3.4835583
+  dec: -18.9018472

--- a/docs/data/sources/tev-000003.yaml
+++ b/docs/data/sources/tev-000003.yaml
@@ -1,0 +1,31 @@
+source_id: 3
+
+common_name: Tycho SNR
+gamma_names: [VER J0025+641]
+other_names:
+- SNR G120.1+1.4
+- 3C10
+- SN1572
+
+where: gal
+classes: [snr]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2010-05
+
+tevcat_id: 209
+tevcat2_id: xCyAjF
+tevcat_name: TeV J0025+641
+
+tgevcat_id: 3
+tgevcat_name: TeV J0025+6410
+
+reference_ids:
+- 2017ApJ...836...23A
+- 2011ApJ...730L..20A
+
+pos:
+  simbad_id: Tycho SNR
+  ra: 6.3397000
+  dec: 64.1408000

--- a/docs/data/sources/tev-000004.yaml
+++ b/docs/data/sources/tev-000004.yaml
@@ -1,0 +1,27 @@
+source_id: 4
+
+common_name: KUV 00311-1938
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2012-07
+
+tevcat_id: 239
+tevcat2_id: PKJZqs
+tevcat_name: TeV J0033-193
+
+tgevcat_id: 4
+tgevcat_name: TeV J0033-1921
+
+reference_ids:
+- 2012AIPC.1505..490B
+
+pos:
+  simbad_id: KUV 00311-1938
+  ra: 8.3932875
+  dec: -19.3592056

--- a/docs/data/sources/tev-000005.yaml
+++ b/docs/data/sources/tev-000005.yaml
@@ -1,0 +1,27 @@
+source_id: 5
+
+common_name: 1ES 0033+595
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2011-10
+
+tevcat_id: 229
+tevcat2_id: eNYfrm
+tevcat_name: TeV J0035+598
+
+tgevcat_id: 5
+tgevcat_name: TeV J0035+5947
+
+reference_ids:
+- 2015MNRAS.446..217A
+
+pos:
+  simbad_id: 1ES 0033+595
+  ra: 8.9689750
+  dec: 59.8344972

--- a/docs/data/sources/tev-000006.yaml
+++ b/docs/data/sources/tev-000006.yaml
@@ -1,0 +1,28 @@
+source_id: 6
+
+common_name: NGC 253
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [galaxy]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2009-07
+
+tevcat_id: 195
+tevcat2_id: sK2rQU
+tevcat_name: TeV J0047-253
+
+tgevcat_id: 6
+tgevcat_name: TeV J0047-2517
+
+reference_ids:
+- 2009Sci...326.1080A
+- 2012ApJ...757..158A
+
+pos:
+  simbad_id: NGC 253
+  ra: 11.8880583
+  dec: -25.2888000

--- a/docs/data/sources/tev-000007.yaml
+++ b/docs/data/sources/tev-000007.yaml
@@ -1,0 +1,34 @@
+source_id: 7
+
+common_name: RGB J0136+391
+gamma_names: []
+other_names:
+- B3 0133+388
+- 1RXS J013632.9+390556
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2012-07
+
+tevcat_id: 244
+tevcat2_id: 7WhQrw
+tevcat_name: TeV J0136+391
+
+tgevcat_id: 7
+tgevcat_name: TeV J0136+3905
+
+reference_ids:
+- 2012AIPC.1505..186M
+
+pos:
+  simbad_id: RGB J0136+391
+  ra: 24.1358267
+  dec: 39.0997773
+
+notes: |
+  Source announced at Gamma 2012.
+  No proceeding or paper yet?
+  Check 2012AIPC.1505..186M

--- a/docs/data/sources/tev-000008.yaml
+++ b/docs/data/sources/tev-000008.yaml
@@ -1,0 +1,29 @@
+source_id: 8
+
+common_name: RGB J0152+017
+gamma_names: []
+other_names:
+- RXJ0152.6+0147
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-02
+
+tevcat_id: 156
+tevcat2_id: tKGVcC
+tevcat_name: TeV J0152+017
+
+tgevcat_id: 8
+tgevcat_name: TeV J0152+0146
+
+pos:
+  simbad_id: RGB J0152+017
+  ra: 28.1650455
+  dec: 1.7881618
+
+reference_ids:
+- 2008A&A...481L.103A
+- 2008bves.confE..46L

--- a/docs/data/sources/tev-000009.yaml
+++ b/docs/data/sources/tev-000009.yaml
@@ -1,0 +1,27 @@
+source_id: 9
+
+common_name: 3C 58
+gamma_names: []
+other_names: []
+
+where: gal
+classes: [pwn]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2014-05
+
+tevcat_id: 252
+tevcat2_id: 2I2TuY
+tevcat_name: TeV J0209+648
+
+tgevcat_id: 9
+tgevcat_name: TeV J0205+6451
+
+pos:
+  simbad_id: 3C 58
+  ra: 31.4043000
+  dec: 64.8283000
+
+reference_ids:
+- 2014A&A...567L...8A

--- a/docs/data/sources/tev-000010.yaml
+++ b/docs/data/sources/tev-000010.yaml
@@ -1,0 +1,29 @@
+source_id: 10
+
+common_name: S3 0218+35
+gamma_names: []
+other_names:
+- B2 0218+35
+
+where: egal
+classes:
+- blazar
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2014-07
+
+tevcat_id: 254
+tevcat2_id: hJnA37
+tevcat_name: TeV J0218+359
+
+tgevcat_id: 10
+tgevcat_name: TeV J0221+3556
+
+pos:
+  simbad_id: S3 0218+35
+  ra: 35.2728000
+  dec: 35.9371000
+
+reference_ids:
+- 2016JPhCS.718e2022M

--- a/docs/data/sources/tev-000011.yaml
+++ b/docs/data/sources/tev-000011.yaml
@@ -1,0 +1,29 @@
+source_id: 11
+
+common_name: 3C 66A
+gamma_names: []
+other_names: [B2 0218+35]
+
+where: egal
+classes: [ibl]
+
+discoverer: crimea
+seen_by: [magic, veritas, crimea]
+discovery_date: 1998-03
+
+tevcat_id: 119
+tevcat2_id: J01xzR
+tevcat_name: TeV J0222+430
+
+tgevcat_id: 11
+tgevcat_name: TeV J0222+4302
+
+pos:
+  simbad_id: 3C 66A
+  ra: 35.6650500
+  dec: 43.0355222
+
+reference_ids:
+- 2009ApJ...693L.104A
+- 2011ApJ...726...43A
+- 2011ApJ...726...58A

--- a/docs/data/sources/tev-000012.yaml
+++ b/docs/data/sources/tev-000012.yaml
@@ -1,0 +1,27 @@
+source_id: 12
+
+common_name: MAGIC J0223+403
+gamma_names: [MAGIC J0223+403]
+other_names: [3C 66A/B Region]
+
+where: unid
+classes: [unid]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2009-02
+
+tevcat_id: 138
+tevcat2_id: y6gVxa
+tevcat_name: TeV J0223+430
+
+tgevcat_id: 12
+tgevcat_name: TeV J0223+4259
+
+pos:
+  simbad_id: 3C 66A
+  ra: 35.6650500
+  dec: 43.0355222
+
+reference_ids:
+- 2009ApJ...692L..29A

--- a/docs/data/sources/tev-000013.yaml
+++ b/docs/data/sources/tev-000013.yaml
@@ -1,0 +1,29 @@
+source_id: 13
+
+common_name: 1ES 0229+200
+gamma_names: [VER J0232+202]
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess, veritas]
+discovery_date: 2006-12
+
+tevcat_id: 130
+tevcat2_id: pVNsSZ
+tevcat_name: TeV J0232+202
+
+tgevcat_id: 13
+tgevcat_name: TeV J0232+2016
+
+pos:
+  simbad_id: 1ES 0229+200
+  ra: 38.2025640
+  dec: 20.2881899
+
+reference_ids:
+- 2007A&A...475L...9A
+- 2011arXiv1110.0038
+- 2014ApJ...782...13A

--- a/docs/data/sources/tev-000014.yaml
+++ b/docs/data/sources/tev-000014.yaml
@@ -1,0 +1,32 @@
+source_id: 14
+
+common_name: LS I +61 303
+gamma_names: [VER J0240+612]
+other_names: []
+
+where: gal
+classes: [bin]
+
+discoverer: magic
+seen_by: [veritas, magic]
+discovery_date: 2006-06
+
+tevcat_id: 89
+tevcat2_id: fW749W
+tevcat_name: TeV J0240+612
+
+tgevcat_id: 14
+tgevcat_name: TeV J0240+6115
+
+pos:
+  simbad_id: LS I +61 303
+  ra: 40.131938163
+  dec: 61.229336515
+
+reference_ids:
+- 2006Sci...312.1771A
+- 2008ApJ...679.1427A
+- 2009ApJ...700.1034A
+- 2011ApJ...738....3A
+- 2013ApJ...779...88A
+- 2016ApJ...817L...7A

--- a/docs/data/sources/tev-000015.yaml
+++ b/docs/data/sources/tev-000015.yaml
@@ -1,0 +1,27 @@
+source_id: 15
+
+common_name: PKS 0301-243
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2012-07
+
+tevcat_id: 240
+tevcat2_id: 5puKGr
+tevcat_name: TeV J0303-241
+
+tgevcat_id: 15
+tgevcat_name: TeV J0303-2407
+
+pos:
+  simbad_id: PKS 0301-243
+  ra: 45.860417
+  dec: -24.119861
+
+reference_ids:
+- 2013A&A...559A.136H

--- a/docs/data/sources/tev-000016.yaml
+++ b/docs/data/sources/tev-000016.yaml
@@ -1,0 +1,27 @@
+source_id: 16
+
+common_name: IC 310
+gamma_names: [MAGIC J0317+413]
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2010-03
+
+tevcat_id: 208
+tevcat2_id: hooot9
+tevcat_name: TeV J0316+413
+
+tgevcat_id: 16
+tgevcat_name: TeV J0316+4119
+
+pos:
+  simbad_id: IC 310
+  ra: 49.1792708
+  dec: 41.3247667
+
+reference_ids:
+- 2014A&A...563A..91A

--- a/docs/data/sources/tev-000017.yaml
+++ b/docs/data/sources/tev-000017.yaml
@@ -1,0 +1,27 @@
+source_id: 17
+
+common_name: RBS 0413
+gamma_names: [VER J0319+187]
+other_names: [RBS 0413, EXO 0317.0+1834, 1E 0317.0+1835]
+
+where: egal
+classes: [hbl]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2009-10
+
+tevcat_id: 198
+tevcat2_id: p26X9Z
+tevcat_name: TeV J0319+187
+
+tgevcat_id: 17
+tgevcat_name: TeV J0319+1845
+
+pos:
+  simbad_id: RBS 0413
+  ra: 49.96585
+  dec: 18.7595556
+
+reference_ids:
+- 2012ApJ...750...94A

--- a/docs/data/sources/tev-000018.yaml
+++ b/docs/data/sources/tev-000018.yaml
@@ -1,0 +1,28 @@
+source_id: 18
+
+common_name: NGC 1275
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [fri]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2010-10
+
+tevcat_id: 212
+tevcat2_id: 9dfnMH
+tevcat_name: TeV J0319+415
+
+tgevcat_id: 18
+tgevcat_name: TeV J0319+4130
+
+pos:
+  simbad_id: NGC 1275
+  ra: 49.950667083
+  dec: 41.511695306
+
+reference_ids:
+- 2012A&A...539L...2A
+- 2016A&A...589A..33A

--- a/docs/data/sources/tev-000019.yaml
+++ b/docs/data/sources/tev-000019.yaml
@@ -1,0 +1,27 @@
+source_id: 19
+
+common_name: 1ES 0347-121
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2007-08
+
+tevcat_id: 147
+tevcat2_id: rWyLLM
+tevcat_name: TeV J0349-119
+
+tgevcat_id: 19
+tgevcat_name: TeV J0349-1158
+
+pos:
+  simbad_id: 1ES 0347-121
+  ra: 57.3466083
+  dec: -11.9908583
+
+reference_ids:
+- 2007A&A...473L..25A

--- a/docs/data/sources/tev-000020.yaml
+++ b/docs/data/sources/tev-000020.yaml
@@ -1,0 +1,29 @@
+source_id: 20
+
+common_name: 1ES 0414+009
+gamma_names: [VER J0416+011]
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess, veritas]
+discovery_date: 2009-11
+
+tevcat_id: 199
+tevcat2_id: hKCHxG
+tevcat_name: TeV J0416+010
+
+tgevcat_id: 20
+tgevcat_name: TeV J0416+0105
+
+pos:
+  simbad_id: 1ES 0414+009
+  ra: 64.2187375
+  dec: 1.0899944
+
+reference_ids:
+- 2013arXiv1307.7051M
+- 2012ApJ...755..118A
+- 2012A&A...538A.103H

--- a/docs/data/sources/tev-000021.yaml
+++ b/docs/data/sources/tev-000021.yaml
@@ -1,0 +1,27 @@
+source_id: 21
+
+common_name: PKS 0447-439
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2009-12
+
+tevcat_id: 203
+tevcat2_id: ewJQZd
+tevcat_name: TeV J0449-438
+
+tgevcat_id: 21
+tgevcat_name: TeV J0449-4350
+
+pos:
+  simbad_id: PKS 0447-439
+  ra: 72.3529167
+  dec: -43.8358139
+
+reference_ids:
+- 2013A&A...552A.118H

--- a/docs/data/sources/tev-000022.yaml
+++ b/docs/data/sources/tev-000022.yaml
@@ -1,0 +1,28 @@
+source_id: 22
+
+common_name: 1ES 0502+675
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2009-11
+
+tevcat_id: 200
+tevcat2_id: 1G0nr7
+tevcat_name: TeV J0507+676
+
+tgevcat_id: 22
+tgevcat_name: TeV J0507+6737
+
+pos:
+  simbad_id: 1ES 0502+675
+  ra: 76.9840583
+  dec: 67.6234056
+
+reference_ids:
+- 2011arXiv1110.0040W
+- atel-2301

--- a/docs/data/sources/tev-000023.yaml
+++ b/docs/data/sources/tev-000023.yaml
@@ -1,0 +1,28 @@
+source_id: 23
+
+common_name: RGB J0521+212
+gamma_names: [VER J0521+211]
+other_names: []
+
+where: egal
+classes: [ibl]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2009-10
+
+tevcat_id: 196
+tevcat2_id: ILT7om
+tevcat_name: TeV J0521+211
+
+tgevcat_id: 23
+tgevcat_name: TeV J0521+2112
+
+pos:
+  simbad_id: RGB J0521+212
+  ra: 80.4415375
+  dec: 21.2142722
+
+reference_ids:
+- 2013ApJ...776...69A
+- atel-2309

--- a/docs/data/sources/tev-000024.yaml
+++ b/docs/data/sources/tev-000024.yaml
@@ -1,0 +1,27 @@
+source_id: 24
+
+common_name: LMC N132D
+gamma_names: []
+other_names: [SNR J052501-693842]
+
+where: egal
+classes: [snr, mc]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2014-10
+
+tevcat_id: 256
+tevcat2_id: z30txh
+tevcat_name: TeV J0525-696
+
+tgevcat_id: 24
+tgevcat_name: TeV J0525-6938
+
+pos:
+  simbad_id: LMC N132D
+  ra: 81.259167
+  dec: -69.644167
+
+reference_ids:
+- 2015Sci...347..406H

--- a/docs/data/sources/tev-000025.yaml
+++ b/docs/data/sources/tev-000025.yaml
@@ -1,0 +1,31 @@
+source_id: 25
+
+common_name: Crab nebula
+gamma_names: []
+other_names: [G184.6-5.8, 3C 144, SN 1054]
+
+where: gal
+classes: [pwn]
+
+discoverer: whipple
+seen_by: [whipple, hess, hegra, magic, veritas, hawc]
+discovery_date: 1989-07
+
+tevcat_id: 74
+tevcat2_id: BlJI6q
+tevcat_name: TeV J0534+220
+
+tgevcat_id: 25
+tgevcat_name: TeV J0534+2200
+
+pos:
+  simbad_id: crab nebula
+  ra: 83.633083
+  dec: 22.0145
+
+reference_ids:
+- 1998ApJ...503..744H
+- 2004ApJ...614..897A
+- 2006A&A...457..899A
+- 2008ICRC....2..803K
+- 2014ApJ...781L..11A

--- a/docs/data/sources/tev-000026.yaml
+++ b/docs/data/sources/tev-000026.yaml
@@ -1,0 +1,27 @@
+source_id: 26
+
+common_name: 30 Dor C
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [other]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2014-10
+
+tevcat_id: 255
+tevcat2_id: C6fp9j
+tevcat_name: TeV J0535-692
+
+tgevcat_id: 26
+tgevcat_name: TeV J0535-6911
+
+pos:
+  simbad_id: 30 Dor C
+  ra: 83.9617
+  dec: -69.2061
+
+reference_ids:
+- 2015Sci...347..406H

--- a/docs/data/sources/tev-000027.yaml
+++ b/docs/data/sources/tev-000027.yaml
@@ -1,0 +1,28 @@
+source_id: 27
+
+common_name: N 157B
+gamma_names: [HESS J0537-691]
+other_names: [LHA 120-N 157B, PSR J0537-6910]
+
+where: egal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2012-01
+
+tevcat_id: 236
+tevcat2_id: 8hS5e7
+tevcat_name: TeV J0537-691
+
+tgevcat_id: 27
+tgevcat_name: TeV J0537-6909
+
+pos:
+  simbad_id: PSR J0537-6910
+  ra: 84.44443
+  dec: -69.17141
+
+reference_ids:
+- 2012A&A...545L...2H
+- 2015Sci...347..406H

--- a/docs/data/sources/tev-000028.yaml
+++ b/docs/data/sources/tev-000028.yaml
@@ -1,0 +1,27 @@
+source_id: 28
+
+common_name: PKS 0548-322
+gamma_names: []
+other_names: [H 0548-322, 1ES 0548-322]
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2007-07
+
+tevcat_id: 133
+tevcat2_id: U09cDa
+tevcat_name: TeV J0550-322
+
+tgevcat_id: 28
+tgevcat_name: TeV J0550-3216
+
+pos:
+  simbad_id: PKS 0548-322
+  ra: 87.6689875
+  dec: -32.2712472
+
+reference_ids:
+- 2010A&A...521A..69A

--- a/docs/data/sources/tev-000029.yaml
+++ b/docs/data/sources/tev-000029.yaml
@@ -1,0 +1,30 @@
+source_id: 29
+
+common_name: IC 443
+gamma_names: [MAGIC 0616+223, VER J0616+223]
+other_names: [3C 157, SNR 189.1+03.0]
+
+where: gal
+classes: [snr]
+
+discoverer: magic
+seen_by: [magic, veritas, milagro]
+discovery_date: 2007-05
+
+tevcat_id: 120
+tevcat2_id: 9xMcgD
+tevcat_name: TeV J0616+225
+
+tgevcat_id: 29
+tgevcat_name: TeV J0616+2230
+
+pos:
+  simbad_id: IC 443
+  ra: 94.51125
+  dec: 22.66
+
+reference_ids:
+- 2007ApJ...664L..87A
+- 2009ApJ...700L.127A
+- 2009ApJ...698L.133A
+- 2015arXiv151201911H

--- a/docs/data/sources/tev-000030.yaml
+++ b/docs/data/sources/tev-000030.yaml
@@ -1,0 +1,33 @@
+source_id: 30
+
+common_name: HESS J0632+057
+gamma_names: [HESS J0632+057, VER J0633+057]
+other_names: [HD 259440]
+
+where: gal
+classes: [bin]
+
+discoverer: hess
+seen_by: [hess, veritas, magic]
+discovery_date: 2007-07
+
+tevcat_id: 134
+tevcat2_id: jPeNQq
+tevcat_name: TeV J0632+058
+
+tgevcat_id: 30
+tgevcat_name: TeV J0632+0548
+
+pos:
+  simbad_id: HD 259440
+  ra: 98.24689375
+  dec: 5.80032722
+
+reference_ids:
+- 2007A&A...469L...1A
+- 2009ApJ...690L.101H
+- 2009ApJ...698L..94A
+- 2012ApJ...754L..10A
+- 2014ApJ...780..168A
+- 2016arXiv161003751S
+- 2017arXiv170804045M

--- a/docs/data/sources/tev-000031.yaml
+++ b/docs/data/sources/tev-000031.yaml
@@ -1,0 +1,30 @@
+source_id: 31
+
+common_name: Geminga
+gamma_names: [MGRO J0632+17]
+other_names: []
+
+where: gal
+classes: [psr, pwn]
+
+discoverer: milagro
+seen_by: [milagro, hawc]
+discovery_date: 2009-04
+
+tevcat_id: 177
+tevcat2_id: 66DvGb
+tevcat_name: TeV J0632+173
+
+tgevcat_id: 31
+tgevcat_name: TeV J0632+1722
+
+pos:
+  simbad_id: Geminga
+  ra: 98.4756375
+  dec: 17.7702528
+
+reference_ids:
+- 2009ApJ...700L.127A
+- 2015arXiv150803497B
+- 2016A&A...591A.138A
+

--- a/docs/data/sources/tev-000032.yaml
+++ b/docs/data/sources/tev-000032.yaml
@@ -1,0 +1,28 @@
+source_id: 32
+
+common_name: RX J0648.7+1516
+gamma_names: [VER J0648+152]
+fermi_names: [1FGL J0648.8+1516]
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2010-03
+
+tevcat_id: 207
+tevcat2_id: 0WgN2s
+tevcat_name: TeV J0648+152
+
+tgevcat_id: 32
+tgevcat_name: TeV J0648+1516 #TeV J06481516
+
+pos:
+  simbad_id: RX J0648.7+1516
+  ra: 102.1984875
+  dec: 15.2735722
+
+reference_ids:
+- 2011ApJ...742..127A

--- a/docs/data/sources/tev-000033.yaml
+++ b/docs/data/sources/tev-000033.yaml
@@ -1,0 +1,31 @@
+source_id: 33
+
+common_name: 1ES 0647+250
+gamma_names: []
+fermi_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic, veritas]
+discovery_date: 2011-09
+
+tevcat_id: 238
+tevcat2_id: zp72d7
+tevcat_name: TeV J0650+250
+
+tgevcat_id: 33
+tgevcat_name: TeV J0650+2503
+
+pos:
+  simbad_id: 1ES 0647+250
+  ra: 102.6937092458
+  dec: 25.0498953861
+
+reference_ids:
+- 2013arXiv1308.0287D
+
+notes: |
+  TODO: No publication by MAGIC or VERITAS?

--- a/docs/data/sources/tev-000034.yaml
+++ b/docs/data/sources/tev-000034.yaml
@@ -1,0 +1,28 @@
+source_id: 34
+
+common_name: RGB J0710+591
+gamma_names: [VER J0710+591]
+fermi_names: [1FGL J0710.6+5911]
+other_names: [RX J0710.5+5908, 1H 0658+595]
+
+where: egal
+classes: [hbl]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2009-02
+
+tevcat_id: 173
+tevcat2_id: vejQq8
+tevcat_name: TeV J0710+591
+
+tgevcat_id: 34
+tgevcat_name: TeV J0710+5909
+
+pos:
+  simbad_id: RGB J0710+591
+  ra: 107.625325
+  dec: 59.1390278
+
+reference_ids:
+- 2010ApJ...715L..49A

--- a/docs/data/sources/tev-000035.yaml
+++ b/docs/data/sources/tev-000035.yaml
@@ -1,0 +1,29 @@
+source_id: 35
+
+common_name: S5 0716+714
+gamma_names: []
+fermi_names: []
+other_names: []
+
+where: egal
+classes: [ibl]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2008-04
+
+tevcat_id: 172
+tevcat2_id: vDwoU3
+tevcat_name: TeV J0721+713
+
+tgevcat_id: 35
+tgevcat_name: TeV J0721+7120
+
+pos:
+  simbad_id: S5 0716+714
+  ra: 110.472701917
+  dec: 71.343434278
+
+reference_ids:
+- 2009ApJ...704L.129A
+- 2009arXiv0907.0366M

--- a/docs/data/sources/tev-000036.yaml
+++ b/docs/data/sources/tev-000036.yaml
@@ -1,0 +1,29 @@
+source_id: 36
+
+common_name: 1ES 0806+524
+gamma_names: []
+fermi_names: []
+other_names: [VTS J0809+522]
+
+where: egal
+classes: [hbl]
+
+discoverer: veritas
+seen_by: [veritas, magic]
+discovery_date: 2008-12
+
+tevcat_id: 160
+tevcat2_id: kIwUzI
+tevcat_name: TeV J0809+523
+
+tgevcat_id: 36
+tgevcat_name: TeV J0809+5219
+
+pos:
+  simbad_id: 1ES 0806+524
+  ra: 122.454944708
+  dec: 52.31618075
+
+reference_ids:
+- 2009ApJ...690L.126A
+- 2015MNRAS.451..739A

--- a/docs/data/sources/tev-000037.yaml
+++ b/docs/data/sources/tev-000037.yaml
@@ -1,0 +1,29 @@
+source_id: 37
+
+common_name: Vela X
+gamma_names:
+- HESS J0835-455
+other_names: []
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2006-03
+
+tevcat_id: 86
+tevcat2_id: yVoFOS
+tevcat_name: TeV J0835-456
+
+tgevcat_id: 37
+tgevcat_name: TeV J0835-4536
+
+pos:
+  simbad_id: Vela X
+  ra: 128.287
+  dec: -45.19
+
+reference_ids:
+- 2012A&A...548A..38A
+- 2006A&A...448L..43A

--- a/docs/data/sources/tev-000038.yaml
+++ b/docs/data/sources/tev-000038.yaml
@@ -1,0 +1,32 @@
+source_id: 38
+
+common_name: RBS 0723
+gamma_names: []
+fermi_names:
+- 1FGL J0847.2+113
+- 2FGL J0847.2+1134
+- 3FGL J0847.1+1134
+- 1FHL J0847.0+1132
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2014-01
+
+tevcat_id: 249
+tevcat2_id: nhyiXQ
+tevcat_name: TeV J0847+115
+
+tgevcat_id: 38
+tgevcat_name: TeV J0847+1133
+
+pos:
+  simbad_id: RBS 0723
+  ra: 131.8038875
+  dec: 11.5639194
+
+reference_ids:
+- http://www.astronomerstelegram.org/?read=5768

--- a/docs/data/sources/tev-000039.yaml
+++ b/docs/data/sources/tev-000039.yaml
@@ -1,0 +1,37 @@
+source_id: 39
+
+common_name: Vela Junior
+gamma_names:
+- HESS J0852-463
+fermi_names:
+- 1FGL J0854.0-4632
+- 2FGL J0851.7-4635
+- 3FGL J0852.7-4631e
+- 1FHL J0852.7-4631
+other_names:
+- RX J0852.0-4622
+- SNR G266.2-01.2
+
+where: gal
+classes: [snr]
+
+discoverer: cangaroo
+seen_by: [cangaroo, hess]
+discovery_date: 2005-02
+
+tevcat_id: 98
+tevcat2_id: FfpuKQ
+tevcat_name: TeV J0852-463
+
+tgevcat_id: 39
+tgevcat_name: TeV J0852-4622
+
+pos:
+  simbad_id: Vela Junior
+  ra: 133.0
+  dec: -46.333
+
+reference_ids:
+- 2016arXiv161101863H
+- 2005A&A...437L...7A
+- 2007ApJ...661..236A

--- a/docs/data/sources/tev-000040.yaml
+++ b/docs/data/sources/tev-000040.yaml
@@ -1,0 +1,32 @@
+source_id: 40
+
+common_name: M 82
+gamma_names: []
+fermi_names:
+- 1FGL J0956.5+6938
+- 2FGL J0955.9+6936
+- 3FGL J0955.4+6940
+other_names: [NGC 3034]
+
+where: egal
+classes: [galaxy]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2009-07
+
+tevcat_id: 194
+tevcat2_id: wN7SNs
+tevcat_name: TeV J0955+696
+
+tgevcat_id: 40
+tgevcat_name: TeV J0955+6940
+
+pos:
+  simbad_id: M 82
+  ra: 148.9684583
+  dec: 69.6797028
+
+reference_ids:
+- 2009Natur.462..770V
+- 2009arXiv0912.3807K

--- a/docs/data/sources/tev-000041.yaml
+++ b/docs/data/sources/tev-000041.yaml
@@ -1,0 +1,27 @@
+source_id: 41
+
+common_name: S4 0954+65
+gamma_names: []
+fermi_names: []
+other_names: []
+
+where: egal
+classes: [blazar]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2015-02
+
+tevcat_id: 258
+tevcat_name: TeV J0958+655
+
+tgevcat_id: 41
+tgevcat_name: TeV J0958+6533
+
+pos:
+  simbad_id: S4 0954+65
+  ra: 149.696854583
+  dec: 65.56522725
+
+reference_ids:
+- http://www.astronomerstelegram.org/?read=7080

--- a/docs/data/sources/tev-000042.yaml
+++ b/docs/data/sources/tev-000042.yaml
@@ -1,0 +1,30 @@
+source_id: 42
+
+common_name: 1RXS J101015.9-311909
+gamma_names: []
+fermi_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2010-12
+
+
+tevcat_id: 215
+tevcat2_id: 7fxWYa
+tevcat_name: TeV J1010-313
+
+tgevcat_id: 42
+tgevcat_name: TeV J1010-3118
+
+pos:
+  simbad_id: 1RXS J101015.9-311909
+  ra: 152.5665542
+  dec: -31.3189917
+
+reference_ids:
+- 2011ICRC....8..109C
+- 2012A&A...542A..94H

--- a/docs/data/sources/tev-000043.yaml
+++ b/docs/data/sources/tev-000043.yaml
@@ -1,0 +1,32 @@
+source_id: 43
+
+common_name: 1ES 1011+496
+gamma_names: []
+fermi_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic, veritas]
+discovery_date: 2007-09
+
+tevcat_id: 153
+tevcat2_id: agykYI
+tevcat_name: TeV J1015+494
+
+tgevcat_id: 43
+tgevcat_name: TeV J1015+4926
+
+pos:
+  simbad_id: 1ES 1011+496
+  ra: 153.767249167
+  dec: 49.433529083
+
+reference_ids:
+- 2007ApJ...667L..21A
+- 2016MNRAS.459.2286A
+- 2016A&A...591A..10A
+- 2015arXiv150103554C
+- 2013arXiv1308.0287D

--- a/docs/data/sources/tev-000044.yaml
+++ b/docs/data/sources/tev-000044.yaml
@@ -1,0 +1,30 @@
+source_id: 44
+
+common_name: HESS J1018-589 B
+gamma_names: [HESS J1018-589 B]
+fermi_names: []
+other_names: [PSR J1016-5857]
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2010-08
+
+tevcat_id: 260
+tevcat2_id: QhYho8
+tevcat_name: TeV J1016-589
+
+tgevcat_id: 44
+tgevcat_name: TeV J1016-5858
+
+pos:
+  simbad_id: PSR J1016-5857
+  ra: 154.088167
+  dec: -58.953361
+
+reference_ids:
+- 2010cosp...38.2803D
+- 2012A&A...541A...5H
+- 2015A&A...577A.131H

--- a/docs/data/sources/tev-000045.yaml
+++ b/docs/data/sources/tev-000045.yaml
@@ -1,0 +1,32 @@
+source_id: 45
+
+common_name: HESS J1018-589 A
+gamma_names: [HESS J1018-589 A]
+fermi_names: []
+other_names:
+- SNR G284.3-01.8
+- MSH 10-53
+
+where: gal
+classes: [bin]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2010-08
+
+tevcat_id: 237
+tevcat2_id: 5FlzLA
+tevcat_name: TeV J1018-589
+
+tgevcat_id: 45
+tgevcat_name: TeV J1018-5856
+
+pos:
+  simbad_id: SNR G284.3-01.8
+  ra: 154.575
+  dec: -59.0
+
+reference_ids:
+- 2015A&A...577A.131H
+- 2012A&A...541A...5H
+- 2015ApJ...813L..26S

--- a/docs/data/sources/tev-000046.yaml
+++ b/docs/data/sources/tev-000046.yaml
@@ -1,0 +1,32 @@
+source_id: 46
+
+common_name: Westerlund 2
+gamma_names: [HESS J1023-575]
+fermi_names: []
+other_names:
+- RCW 49
+- WR20a
+- PSR J1022-5746
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2007-06
+
+tevcat_id: 132
+tevcat2_id: nvPEhx
+tevcat_name: TeV J1023-577
+
+tgevcat_id: 46
+tgevcat_name: TeV J1023-5747
+
+pos:
+  simbad_id: HESS J1023-575
+  ra: 155.75
+  dec: -57.5
+
+reference_ids:
+- 2007A&A...467.1075A
+- 2011A&A...525A..46H

--- a/docs/data/sources/tev-000047.yaml
+++ b/docs/data/sources/tev-000047.yaml
@@ -1,0 +1,29 @@
+source_id: 47
+
+common_name: HESS J1026-582
+gamma_names: [HESS J1026-582]
+fermi_names: []
+other_names:
+- PSR J1028-5819
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2011-01
+
+tevcat_id: 220
+tevcat2_id: UwjiUu
+tevcat_name: TeV J1026-582
+
+tgevcat_id: 47
+tgevcat_name: TeV J1026-5812
+
+pos:
+  simbad_id: HESS J1026-582
+  ra: 157.16583
+  dec: -58.29194
+
+reference_ids:
+- 2011A&A...525A..46H

--- a/docs/data/sources/tev-000048.yaml
+++ b/docs/data/sources/tev-000048.yaml
@@ -1,0 +1,29 @@
+source_id: 48
+
+common_name: 1ES 1101-232
+gamma_names: [HESS J1103-234]
+fermi_names: []
+other_names:
+- 1H 1100-230
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2006-04
+
+tevcat_id: 97
+tevcat2_id: 2Z3QTH
+tevcat_name: TeV J1103-234
+
+tgevcat_id: 48
+tgevcat_name: TeV J1103-2329
+
+pos:
+  simbad_id: 1ES 1101-232
+  ra: 165.9066917
+  dec: -23.491975
+
+reference_ids:
+- 2007A&A...470..475A

--- a/docs/data/sources/tev-000049.yaml
+++ b/docs/data/sources/tev-000049.yaml
@@ -1,0 +1,54 @@
+source_id: 49
+
+common_name: Markarian 421
+gamma_names:
+- HESS J1104+382
+fermi_names: []
+other_names:
+- Markarian 421
+- Mrk 421
+- 1ES 1101+384
+- 1H 1104+382
+- H 1105+38
+
+where: egal
+classes: [hbl]
+
+discoverer: whipple
+seen_by: [whipple, veritas, hess, magic, hawc]
+discovery_date: 1992-08
+
+tevcat_id: 75
+tevcat2_id: cIB7Uf
+tevcat_name: TeV J1104+382
+
+tgevcat_id: 49
+tgevcat_name: TeV J1104+3811
+
+pos:
+  simbad_id: Markarian 421
+  ra: 166.113808083
+  dec: 38.208833083
+
+reference_ids:
+- 1996ApJ...460..644S
+- 1996ApJ...472L...9B
+- 1999A&A...350..757A
+- 1999ApJ...526L..81M
+- 2000PhDT.........6P
+- 2000AIPC..515..113P
+- 2002A&A...393...89A
+- 2003ApJ...598..242A
+- 2005A&A...437...95A
+- 2006ApJ...641..740R
+- 2007ApJ...663..125A
+- 2009ApJ...691L..13D
+- 2010A&A...519A..32A
+- 2010JPhG...37l5201C
+- 2011ApJ...734..110B
+- 2011ApJ...738...25A
+- 2012JPhG...39d5201C
+- 2015NIMPA.770...42S
+- 2017ApJ...834....2A
+
+

--- a/docs/data/sources/tev-000050.yaml
+++ b/docs/data/sources/tev-000050.yaml
@@ -1,0 +1,33 @@
+source_id: 50
+
+common_name: HESS J1119-614
+gamma_names:
+- HESS J1119-614
+fermi_names: []
+other_names:
+- SNR G292.2-00.5
+- PSR J1119-6127
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2009-07
+
+tevcat_id: 205
+tevcat2_id: 1wyMpL
+tevcat_name: TeV J1119-614
+
+tgevcat_id: 50
+tgevcat_name: TeV J1119-6124
+
+pos:
+  simbad_id: HESS J1119-614
+  ra: 169.809583
+  dec: -61.46375
+
+reference_ids:
+- https://www.mpi-hd.mpg.de/hfm/HESS/pages/home/som/2009/11/
+- http://cxc.harvard.edu/cdo/snr09/pres/DjannatiAtai_Arache_v2.pdf
+- 2013ApJ...773...77A

--- a/docs/data/sources/tev-000051.yaml
+++ b/docs/data/sources/tev-000051.yaml
@@ -1,0 +1,29 @@
+source_id: 51
+
+common_name: RX J1136.5+6737
+gamma_names: []
+fermi_names: []
+other_names:
+- RBS 1004
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2014-04
+
+tevcat_id: 251
+tevcat2_id: 6T4fxx
+tevcat_name: TeV J1136+676
+
+tgevcat_id: 51
+tgevcat_name: TeV J1136+6737
+
+pos:
+  simbad_id: RX J1136.5+6737
+  ra: 174.1253628917
+  dec: 67.6178736833
+
+reference_ids:
+- http://www.astronomerstelegram.org/?read=6062

--- a/docs/data/sources/tev-000052.yaml
+++ b/docs/data/sources/tev-000052.yaml
@@ -1,0 +1,34 @@
+source_id: 52
+
+common_name: Markarian 180
+gamma_names: []
+fermi_names: []
+other_names:
+- Mrk 180
+- 1ES 1133+704
+- 1H 1137+699
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2006-09
+
+tevcat_id: 123
+tevcat2_id: mijtir
+tevcat_name: TeV J1136+701
+
+tgevcat_id: 52
+tgevcat_name: TeV J1136+7009
+
+pos:
+  simbad_id: Markarian 180
+  ra: 174.110035042
+  dec: 70.157585278
+
+reference_ids:
+- 2016PhRvD..93d3011H
+- 2011arXiv1109.6808R
+- 2011arXiv1110.6341R
+- 2006ApJ...648L.105A

--- a/docs/data/sources/tev-000053.yaml
+++ b/docs/data/sources/tev-000053.yaml
@@ -1,0 +1,34 @@
+source_id: 53
+
+common_name: 1ES 1215+303
+gamma_names: [VER J1217+301]
+fermi_names: []
+other_names:
+- B2 1215+30
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic, hess]
+discovery_date: 2011-01
+
+tevcat_id: 219
+tevcat2_id: 891TG0
+tevcat_name: TeV J1217+301
+
+tgevcat_id: 53
+tgevcat_name: TeV J1217+3006
+
+pos:
+  simbad_id: 1ES 1215+303
+  ra: 184.46700833
+  dec: 30.11684333
+
+reference_ids:
+- 2011arXiv1110.0038W
+- 2012AIPC.1505..538P
+- http://www.astronomerstelegram.org/?read=3100
+- 2012A&A...544A.142A
+- 2013ApJ...779...92A
+- 2017ApJ...836..205A

--- a/docs/data/sources/tev-000054.yaml
+++ b/docs/data/sources/tev-000054.yaml
@@ -1,0 +1,31 @@
+source_id: 54
+
+common_name: W Comae
+gamma_names: []
+fermi_names: []
+other_names:
+- B2 1219+28
+
+where: egal
+classes: [ibl]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2008-08
+
+tevcat_id: 159
+tevcat2_id: XQhcCi
+tevcat_name: TeV J1221+282
+
+tgevcat_id: 54
+tgevcat_name: TeV J1221+2813
+
+pos:
+  simbad_id: W Comae
+  ra: 185.382043833
+  dec: 28.232916722
+
+reference_ids:
+- 2008ApJ...684L..73A
+- 2009ApJ...707..612A
+- 2015arXiv150807347J

--- a/docs/data/sources/tev-000055.yaml
+++ b/docs/data/sources/tev-000055.yaml
@@ -1,0 +1,36 @@
+source_id: 55
+
+common_name: 1ES 1218+304
+gamma_names:
+- VER J1221+301
+fermi_names: []
+other_names:
+- 1H 1219+301
+- H 1219+305
+- QSO B1218+304
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic, veritas]
+discovery_date: 2006-05
+
+tevcat_id: 91
+tevcat2_id: urWmHx
+tevcat_name: TeV J1221+301
+
+tgevcat_id: 55
+tgevcat_name: TeV J1221+3011
+
+pos:
+  simbad_id: 1ES 1218+304
+  ra: 185.3414278125
+  dec: 30.1769891083
+
+reference_ids:
+- 2009ApJ...695.1370A
+- 2010ApJ...709L.163A
+- 2011arXiv1110.6786L
+- 2011ICRC....8..151C
+- 2014ApJ...788..158A

--- a/docs/data/sources/tev-000056.yaml
+++ b/docs/data/sources/tev-000056.yaml
@@ -1,0 +1,32 @@
+source_id: 56
+
+common_name: PKS 1222+216
+gamma_names: []
+fermi_names: []
+other_names:
+- 4C +21.35
+
+where: egal
+classes: [fsrq]
+
+discoverer: magic
+seen_by: [magic, veritas]
+discovery_date: 2010-06
+
+tevcat_id: 210
+tevcat2_id: dDaGC0
+tevcat_name: TeV J1224+213
+
+tgevcat_id: 56
+tgevcat_name: TeV J1224+2122
+
+pos:
+  simbad_id: PKS 1222+216
+  ra: 186.22692
+  dec: 21.3795625
+
+reference_ids:
+- http://www.astronomerstelegram.org/?read=5981
+- http://www.astronomerstelegram.org/?read=2684
+- 2011ApJ...730L...8A
+- 2015arXiv150103554C

--- a/docs/data/sources/tev-000057.yaml
+++ b/docs/data/sources/tev-000057.yaml
@@ -1,0 +1,29 @@
+source_id: 57
+
+common_name: MS1221.8+2452
+gamma_names: []
+fermi_names: []
+other_names:
+- RGB J1224+246
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2013-05
+
+tevcat_id: 245
+tevcat2_id: LpjBMP
+tevcat_name: TeV J1224+246
+
+tgevcat_id: 57
+tgevcat_name: TeV J1224+2436
+
+pos:
+  simbad_id: MS1221.8+2452
+  ra: 186.100775925
+  dec: 24.6065282556
+
+reference_ids:
+- http://www.astronomerstelegram.org/?read=5038

--- a/docs/data/sources/tev-000058.yaml
+++ b/docs/data/sources/tev-000058.yaml
@@ -1,0 +1,37 @@
+source_id: 58
+
+common_name: M 87
+gamma_names: [VER J1230+123]
+fermi_names: []
+other_names:
+- 1ES 1228+126
+- 1H 1226+128
+
+where: egal
+classes: [fri]
+
+discoverer: hegra
+seen_by: [hegra, hess, veritas, magic]
+discovery_date: 2003-05
+
+tevcat_id: 80
+tevcat2_id: XheKQH
+tevcat_name: TeV J1230+123
+
+tgevcat_id: 58
+tgevcat_name: TeV J1230+1223
+
+pos:
+  simbad_id: M 87
+  ra: 187.70593075
+  dec: 12.391123306
+
+reference_ids:
+- 2003A&A...403L...1A
+- 2006Sci...314.1424A
+- 2008ApJ...679..397A
+- 2010ApJ...716..819A
+- 2012A&A...544A..96A
+- 2012ApJ...746..141A
+- 2012ApJ...746..151A
+

--- a/docs/data/sources/tev-000059.yaml
+++ b/docs/data/sources/tev-000059.yaml
@@ -1,0 +1,31 @@
+source_id: 59
+
+common_name: 3C 279
+gamma_names: []
+fermi_names: []
+other_names: []
+
+where: egal
+classes: [fsrq]
+
+discoverer: magic
+seen_by: [magic, hess]
+discovery_date: 2008-06
+
+tevcat_id: 166
+tevcat2_id: YmUotO
+tevcat_name: TeV J1256-057
+
+tgevcat_id: 59
+tgevcat_name: TeV J1256-0547
+
+pos:
+  simbad_id: 3C 279
+  ra: 194.046527375
+  dec: -5.789312417
+
+reference_ids:
+- 2008AIPC.1085..423E
+- 2008Sci...320.1752M
+- 2011A&A...530A...4A
+- 2016arXiv161005523C

--- a/docs/data/sources/tev-000060.yaml
+++ b/docs/data/sources/tev-000060.yaml
@@ -1,0 +1,31 @@
+source_id: 60
+
+common_name: PSR B1259-63
+gamma_names: [HESS J1302-638]
+fermi_names: []
+other_names:
+- SS 2883
+
+where: gal
+classes: [bin]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2005-10
+
+tevcat_id: 93
+tevcat2_id: HJQC5t
+tevcat_name: TeV J1302-638
+
+tgevcat_id: 60
+tgevcat_name: TeV J1302-6349
+
+pos:
+  simbad_id: PSR B1259-63
+  ra: 195.6985625
+  dec: -63.8357417
+
+reference_ids:
+- 2005A&A...442....1A
+- 2009A&A...507..389A
+- 2013A&A...551A..94H

--- a/docs/data/sources/tev-000061.yaml
+++ b/docs/data/sources/tev-000061.yaml
@@ -1,0 +1,30 @@
+source_id: 61
+
+common_name: HESS J1303-631
+gamma_names: []
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2005-09
+
+tevcat_id: 94
+tevcat2_id: 4au9RH
+tevcat_name: TeV J1303-631
+
+tgevcat_id: 61
+tgevcat_name: TeV J1302-6310
+
+pos:
+  simbad_id: HESS J1303-631
+  ra: 195.75167
+  dec: -63.19861
+
+reference_ids:
+- 2005A&A...439.1013A
+- 2012A&A...548A..46H
+- 2013ApJ...773...77A

--- a/docs/data/sources/tev-000062.yaml
+++ b/docs/data/sources/tev-000062.yaml
@@ -1,0 +1,29 @@
+source_id: 62
+
+common_name: 1ES 1312-423
+gamma_names: []
+fermi_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2010-12
+
+tevcat_id: 216
+tevcat2_id: 7uB4QE
+tevcat_name: TeV J1315-426
+
+tgevcat_id: 62
+tgevcat_name: TeV J1314-4235
+
+pos:
+  simbad_id: 1ES 1312-423
+  ra: 198.7641458
+  dec: -42.6138028
+
+reference_ids:
+- 2011ICRC....8..109C
+- 2013MNRAS.434.1889H

--- a/docs/data/sources/tev-000063.yaml
+++ b/docs/data/sources/tev-000063.yaml
@@ -1,0 +1,29 @@
+source_id: 63
+
+common_name: Centaurus A
+gamma_names: []
+fermi_names: []
+other_names:
+- Cen A
+
+where: egal
+classes: [fri]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2009-03
+
+tevcat_id: 122
+tevcat2_id: ubPSXn
+tevcat_name: TeV J1325-430
+
+tgevcat_id: 63
+tgevcat_name: TeV J1325-4300
+
+pos:
+  simbad_id: Centaurus A
+  ra: 201.365062792
+  dec: -43.019112583
+
+reference_ids:
+- 2009ApJ...695L..40A

--- a/docs/data/sources/tev-000064.yaml
+++ b/docs/data/sources/tev-000064.yaml
@@ -1,0 +1,31 @@
+source_id: 64
+
+common_name: HESS J1356-645
+gamma_names: [HESS J1356-645]
+fermi_names: []
+other_names:
+- PSR J1357-6429
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-12
+
+tevcat_id: 170
+tevcat2_id: ms0x8h
+tevcat_name: TeV J1356-645
+
+tgevcat_id: 64
+tgevcat_name: TeV J1356-6430
+
+pos:
+  simbad_id: HESS J1356-645
+  ra: 209.0
+  dec: -64.5
+
+reference_ids:
+- 2008AIPC.1085..285R
+- 2011A&A...533A.103H
+- 2013ApJ...773...77A

--- a/docs/data/sources/tev-000065.yaml
+++ b/docs/data/sources/tev-000065.yaml
@@ -1,0 +1,30 @@
+source_id: 65
+
+common_name: HESS J1418-609
+gamma_names: [HESS J1418-609]
+fermi_names: []
+other_names:
+- Kookaburra
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2006-09
+
+tevcat_id: 125
+tevcat2_id: r1X1KA
+tevcat_name: TeV J1418-609
+
+tgevcat_id: 65
+tgevcat_name: TeV J1418-6058
+
+pos:
+  simbad_id: HESS J1418-609
+  ra: 214.51667
+  dec: -60.97528
+
+reference_ids:
+- 2006A&A...456..245A
+- 2013ApJ...773...77A

--- a/docs/data/sources/tev-000066.yaml
+++ b/docs/data/sources/tev-000066.yaml
@@ -1,0 +1,32 @@
+source_id: 66
+
+common_name: HESS J1420-607
+gamma_names: [HESS J1420-607]
+fermi_names: []
+other_names:
+- PSR J1420-6048
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2006-09
+
+tevcat_id: 124
+tevcat2_id: zUDsnw
+tevcat_name: TeV J1420-607
+
+tgevcat_id: 66
+tgevcat_name: TeV J1420-6045
+
+pos:
+  simbad_id: HESS J1420-607
+  ra: 214.6917
+  dec: -60.9783
+
+reference_ids:
+- 2006A&A...456..245A
+- 2012A&A...543L...9N
+- 2012ApJ...750..162K
+- 2013ApJ...773...77A

--- a/docs/data/sources/tev-000067.yaml
+++ b/docs/data/sources/tev-000067.yaml
@@ -1,0 +1,33 @@
+source_id: 67
+
+common_name: PKS 1424+240
+gamma_names: [VER J1427+237]
+fermi_names: []
+other_names:
+- 7C 1424+2401
+
+where: egal
+classes: [hbl]
+
+discoverer: veritas
+seen_by: [veritas, magic]
+discovery_date: 2009-06
+
+tevcat_id: 184
+tevcat2_id: lGHxlE
+tevcat_name: TeV J1427+238
+
+tgevcat_id: 67
+tgevcat_name: TeV J1427+2347 #TeV J14272347
+
+pos:
+  simbad_id: PKS 1424+240
+  ra: 216.751632458
+  dec: 23.800010444
+
+reference_ids:
+- 2010ApJ...708L.100A
+- 2014ApJ...785L..16A
+- 2014A&A...567A.135A
+- 2015arXiv150807251B
+- 2016A&A...589A..92R

--- a/docs/data/sources/tev-000068.yaml
+++ b/docs/data/sources/tev-000068.yaml
@@ -1,0 +1,35 @@
+source_id: 68
+
+common_name: HESS J1427-608
+gamma_names: []
+fermi_names: []
+other_names:
+- Suzaku J1427-6051
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2007-07
+
+tevcat_id: 139
+tevcat2_id: eee9un
+tevcat_name: TeV J1427-608
+
+tgevcat_id: 68
+tgevcat_name: TeV J1427-6051
+
+pos:
+  simbad_id: HESS J1427-608
+  ra: 216.96667
+  dec: -60.85
+
+reference_ids:
+- 2008A&A...477..353A
+- 2011arXiv1111.1634T
+- 2011ICRC....6..202T
+- 2013ApJ...773..139V
+- 2013arXiv1308.1626V
+- 2013PASJ...65...61F
+- 2016arXiv160901125G

--- a/docs/data/sources/tev-000069.yaml
+++ b/docs/data/sources/tev-000069.yaml
@@ -1,0 +1,32 @@
+source_id: 69
+
+common_name: H 1426+428
+gamma_names: []
+fermi_names: []
+other_names:
+- 1ES 1426+428
+- 1H 1430+423
+
+where: egal
+classes: [hbl]
+
+discoverer: whipple
+seen_by: [whipple, hegra, magic, veritas]
+discovery_date: 2002-02
+
+tevcat_id: 78
+tevcat2_id: F5cSH7
+tevcat_name: TeV J1428+426
+
+tgevcat_id: 69
+tgevcat_name: TeV J1428+4240
+
+pos:
+  simbad_id: H 1426+428
+  ra: 217.1358706208
+  dec: 42.6725130889
+
+reference_ids:
+- 2002ApJ...571..753H
+- 2002A&A...384L..23A
+- 2003A&A...403..523A

--- a/docs/data/sources/tev-000070.yaml
+++ b/docs/data/sources/tev-000070.yaml
@@ -1,0 +1,36 @@
+source_id: 70
+
+common_name: RCW 86
+gamma_names:
+- HESS J1442-624
+other_names:
+- G315.4-2.3
+- MSH 14-63
+
+where: gal
+classes: [snr]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-10
+
+tevcat_id: 168
+tevcat2_id: gc4bRT
+tevcat_name: TeV J1442-624
+
+tgevcat_id: 70
+tgevcat_name: TeV J1442-6226
+
+pos:
+  simbad_id: RCW 86
+  ra: 220.1208
+  dec: -62.645
+
+reference_ids:
+- 2009Sci...325..719H
+- 2009ApJ...692.1500A
+- 2011ApJ...741...96W
+- 2014A&A...562A.141M
+- 2015APh....65...80M
+- 2016arXiv160104461H
+- 2016arXiv160106534T

--- a/docs/data/sources/tev-000071.yaml
+++ b/docs/data/sources/tev-000071.yaml
@@ -1,0 +1,32 @@
+source_id: 71
+
+common_name: 1ES 1440+122
+gamma_names: [VER J1443+120]
+fermi_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2010-08
+
+tevcat_id: 85
+tevcat2_id: 57tu8J
+tevcat_name: TeV J1443+120
+
+tgevcat_id: 71
+tgevcat_name: TeV J1442+1200
+
+pos:
+  simbad_id: 1ES 1440+122
+  ra: 220.701152425
+  dec: 12.0112152417
+
+reference_ids:
+- http://www.astronomerstelegram.org/?read=2786
+- 2011arXiv1110.0040W
+- 2011ICRC....8...43M
+- 2015arXiv150103554C
+- 2016MNRAS.461..202A

--- a/docs/data/sources/tev-000072.yaml
+++ b/docs/data/sources/tev-000072.yaml
@@ -1,0 +1,30 @@
+source_id: 72
+
+common_name: HESS J1457-593
+gamma_names: [HESS J1457-593]
+fermi_names: []
+other_names:
+- G318.2+00.1
+- G318.2+0.1
+
+where: gal
+classes: [snr, mc]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2010-12
+
+tevcat_id: 222
+tevcat2_id: MN9aoz
+tevcat_name: TeV J1457-594
+
+tgevcat_id: 72
+tgevcat_name: TeV J1457-5928
+
+pos:
+  simbad_id: SNR G318.2+00.1
+  ra: 223.7
+  dec: -59.067
+
+reference_ids:
+- 2010tsra.confE.196H

--- a/docs/data/sources/tev-000073.yaml
+++ b/docs/data/sources/tev-000073.yaml
@@ -1,0 +1,31 @@
+source_id: 73
+
+common_name: HESS J1458-608
+gamma_names: [HESS J1458-608]
+fermi_names: []
+other_names:
+- PSR J1459-6053
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2012-04
+
+tevcat_id: 241
+tevcat2_id: hksZjo
+tevcat_name: TeV J1459-608
+
+tgevcat_id: 73
+tgevcat_name: TeV J1458-6052
+
+pos:
+  simbad_id: HESS J1458-608
+  ra: 224.87417
+  dec: -60.87806
+
+reference_ids:
+- 2011ICRC....7..158G
+- 2012arXiv1205.0719D
+- 2013ApJ...773...77A

--- a/docs/data/sources/tev-000074.yaml
+++ b/docs/data/sources/tev-000074.yaml
@@ -1,0 +1,37 @@
+source_id: 74
+
+common_name: SN 1006
+gamma_names: [HESS J1502-421, HESS J1504-418]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [snr]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-12
+
+tevcat_id: 171
+tevcat2_id: lys1PH
+tevcat_name: TeV J1502-421
+
+tgevcat_id: 74
+tgevcat_name: TeV J1502-4107
+
+pos:
+  simbad_id: SN 1006
+  ra: 225.59208
+  dec: -42.09694
+
+reference_ids:
+- 2010A&A...516A..62A
+
+notes: |
+  In TeVCat, there's two sources listed for SN 1006:
+  - SN 1006 NE = HESS J1504-418
+  - SN 1006 SW = HESS J1502-421
+  I (Christoph Deil) prefer to have it as one source,
+  because it's one cosmic accelerator.
+  This is consistent with other SNRs that are also not
+  split into multiple sources.

--- a/docs/data/sources/tev-000075.yaml
+++ b/docs/data/sources/tev-000075.yaml
@@ -1,0 +1,28 @@
+source_id: 75
+
+common_name: HESS J1503-582
+gamma_names: [HESS J1503-582]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-12
+
+tevcat_id: 169
+tevcat2_id: LuGtCl
+tevcat_name: TeV J1503-582
+
+tgevcat_id: 75
+tgevcat_name: TeV J1503-5813
+
+pos:
+  simbad_id: HESS J1503-582
+  ra: 225.75
+  dec: -58.2
+
+reference_ids:
+- 2008AIPC.1085..281R

--- a/docs/data/sources/tev-000077.yaml
+++ b/docs/data/sources/tev-000077.yaml
@@ -1,0 +1,38 @@
+source_id: 77
+
+common_name: HESS J1507-622
+gamma_names: []
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2009-12
+
+tevcat_id: 204
+tevcat2_id: jNYEaw
+tevcat_name: TeV J1506-623
+
+tgevcat_id: 77
+tgevcat_name: TeV J1506-6221
+
+pos:
+  simbad_id: HESS J1507-622
+  ra: 226.875
+  dec: -62.417
+
+reference_ids:
+- 2009arXiv0912.4229T
+- 2011AdSpR..47..640D
+- 2011arXiv1111.1634T
+- 2011ICRC....6..202T
+- 2011A&A...525A..45H
+- 2012A&A...545A..94D
+- 2013ApJ...773..139V
+- 2013arXiv1308.1626V
+- 2013ApJ...773...77A
+- 2015MNRAS.447.3564E
+

--- a/docs/data/sources/tev-000078.yaml
+++ b/docs/data/sources/tev-000078.yaml
@@ -1,0 +1,28 @@
+source_id: 78
+
+common_name: PKS 1510-089
+gamma_names: []
+fermi_names: []
+other_names: []
+
+where: egal
+classes: [fsrq]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2010-03
+
+tevcat_id: 206
+tevcat2_id: hptayL
+tevcat_name: TeV J1512-091
+
+tgevcat_id: 78
+tgevcat_name: TeV J1512-0906
+
+pos:
+  simbad_id: PKS 1510-089
+  ra: 228.210553833
+  dec: -9.099952667
+
+reference_ids:
+- 2013A&A...554A.107H

--- a/docs/data/sources/tev-000079.yaml
+++ b/docs/data/sources/tev-000079.yaml
@@ -1,0 +1,30 @@
+source_id: 79
+
+common_name: MSH 15-5-02
+gamma_names: [HESS J1514-591]
+other_names:
+- G320.3-01.1
+- MSH 15-52
+
+where: gal
+classes: [pwn]
+
+discoverer: cangaroo
+seen_by: [cangaroo, hess]
+discovery_date: 2005-05
+
+tevcat_id: 95
+tevcat2_id: OhJ7Hr
+tevcat_name: TeV J1514-591
+
+tgevcat_id: 79
+tgevcat_name: TeV J1513-5914
+
+pos:
+  simbad_id: MSH 15-5-02
+  ra: 228.3208
+  dec: -59.0817
+
+reference_ids:
+- 2005A&A...435L..17A
+- 2013ApJ...773...77A

--- a/docs/data/sources/tev-000080.yaml
+++ b/docs/data/sources/tev-000080.yaml
@@ -1,0 +1,29 @@
+source_id: 80
+
+common_name: AP Librae
+gamma_names: []
+fermi_names: []
+other_names:
+- PKS B1514-241
+
+where: egal
+classes: [lbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2010-07
+
+tevcat_id: 202
+tevcat2_id: qpaBdR
+tevcat_name: TeV J1517-243
+
+tgevcat_id: 80
+tgevcat_name: TeV J1517-2422
+
+pos:
+  simbad_id: AP Librae
+  ra: 229.424221375
+  dec: -24.372076472
+
+reference_ids:
+- 2015A&A...573A..31H

--- a/docs/data/sources/tev-000081.yaml
+++ b/docs/data/sources/tev-000081.yaml
@@ -1,0 +1,30 @@
+source_id: 81
+
+common_name: SNR G327.1-1.1
+gamma_names: [HESS J1554-550]
+fermi_names: []
+other_names:
+- SNR G327.1-01.1
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2012-01
+
+tevcat_id: 235
+tevcat2_id: Xq3nlo
+tevcat_name: TeV J1554-550
+
+tgevcat_id: 81
+tgevcat_name: TeV J1554-5505
+
+pos:
+  simbad_id: SNR G327.1-1.1
+  ra: 238.63462
+  dec: -55.06226
+
+reference_ids:
+- 2011ICRC....7..185A
+- 2016ApJ...820..100M

--- a/docs/data/sources/tev-000082.yaml
+++ b/docs/data/sources/tev-000082.yaml
@@ -1,0 +1,32 @@
+source_id: 82
+
+common_name: PG 1553+113
+gamma_names: [HESS J1555+111, VER J1555+111]
+fermi_names: []
+other_names:
+- 1ES 1553+113
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess, magic, veritas]
+discovery_date: 2006-03
+
+tevcat_id: 102
+tevcat2_id: ffHtfX
+tevcat_name: TeV J1555+111
+
+tgevcat_id: 82
+tgevcat_name: TeV J1555+1111
+
+pos:
+  simbad_id: PG 1553+113
+  ra: 238.92935
+  dec: 11.19010167
+
+reference_ids:
+- 2008A&A...477..481A
+- 2012ApJ...748...46A
+- 2015ApJ...802...65A
+- 2015ApJ...799....7A

--- a/docs/data/sources/tev-000083.yaml
+++ b/docs/data/sources/tev-000083.yaml
@@ -1,0 +1,34 @@
+source_id: 83
+
+common_name: HESS J1614-518
+gamma_names: [HESS J1614-518]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2005-03
+
+tevcat_id: 234
+tevcat2_id: ChXqoJ
+tevcat_name: TeV J1614-518
+
+tgevcat_id: 83
+tgevcat_name: TeV J1614-5149
+
+pos:
+  simbad_id: HESS J1614-518
+  ra: 243.5625
+  dec: -51.819083
+
+reference_ids:
+- 2005Sci...307.1938A
+- 2006ApJ...636..777A
+- 2008PASJ...60S.163M
+- 2008AIPC.1085..241R
+- 2010ASPC..422..265O
+- 2011PASJ...63S.879S
+- 2013ApJ...773...77A

--- a/docs/data/sources/tev-000084.yaml
+++ b/docs/data/sources/tev-000084.yaml
@@ -1,0 +1,35 @@
+source_id: 84
+
+common_name: HESS J1616-508
+gamma_names: [HESS J1616-508]
+fermi_names: []
+other_names:
+- PSR J1617-5055
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2005-03
+
+tevcat_id: 104
+tevcat2_id: 2m5UkC
+tevcat_name: TeV J1616-508
+
+tgevcat_id: 84
+tgevcat_name: TeV J1616-5054
+
+pos:
+  simbad_id: HESS J1616-508
+  ra: 244.06
+  dec: -50.91
+
+reference_ids:
+- 2005Sci...307.1938A
+- 2006ApJ...636..777A
+- 2007MNRAS.380..926L
+- 2009ApJ...690..891K
+- 2011ICRC....6..202T
+- 2011arXiv1111.1634T
+- 2013ApJ...773...77A

--- a/docs/data/sources/tev-000085.yaml
+++ b/docs/data/sources/tev-000085.yaml
@@ -1,0 +1,31 @@
+source_id: 85
+
+common_name: HESS J1626-490
+gamma_names: [HESS J1626-490]
+fermi_names: []
+other_names:
+- SNR G335.2+00.1
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2007-07
+
+tevcat_id: 137
+tevcat2_id: ctBOIp
+tevcat_name: TeV J1626-490
+
+tgevcat_id: 85
+tgevcat_name: TeV J1626-4905
+
+pos:
+  simbad_id: HESS J1626-490
+  ra: 246.51667
+  dec: -49.08694
+
+reference_ids:
+- 2008A&A...477..353A
+- 2011arXiv1110.1252E
+- 2013ApJ...773...77A

--- a/docs/data/sources/tev-000086.yaml
+++ b/docs/data/sources/tev-000086.yaml
@@ -1,0 +1,28 @@
+source_id: 86
+
+common_name: HESS J1632-478
+gamma_names: [HESS J1632-478]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2006-01
+
+tevcat_id: 105
+tevcat2_id: p9DNQ0
+tevcat_name: TeV J1632-478
+
+tgevcat_id: 86
+tgevcat_name: TeV J1632-4749
+
+pos:
+  simbad_id: HESS J1632-478
+  ra: 248.00778
+  dec: -47.87452
+
+reference_ids:
+- 2006ApJ...636..777A

--- a/docs/data/sources/tev-000087.yaml
+++ b/docs/data/sources/tev-000087.yaml
@@ -1,0 +1,29 @@
+source_id: 87
+
+common_name: HESS J1634-472
+gamma_names: [HESS J1634-472]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2006-01
+
+tevcat_id: 106
+tevcat2_id: qne6F2
+tevcat_name: TeV J1634-472
+
+tgevcat_id: 87
+tgevcat_name: TeV J1634-4716
+
+pos:
+  simbad_id: HESS J1634-472
+  ra: 248.5
+  dec: -47.2
+
+reference_ids:
+- 2006ApJ...636..777A
+- 2013ApJ...773...77A

--- a/docs/data/sources/tev-000088.yaml
+++ b/docs/data/sources/tev-000088.yaml
@@ -1,0 +1,30 @@
+source_id: 88
+
+common_name: HESS J1640-465
+gamma_names: [HESS J1640-465]
+fermi_names: []
+other_names:
+- SNR G338.3-0.0
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2005-03
+
+tevcat_id: 107
+tevcat2_id: QAgfnh
+tevcat_name: TeV J1640-465
+
+tgevcat_id: 88
+tgevcat_name: TeV J1640-4631
+
+pos:
+  simbad_id: HESS J1640-465
+  ra: 250.125
+  dec: -46.55
+
+reference_ids:
+- 2006ApJ...636..777A
+- 2014MNRAS.439.2828A

--- a/docs/data/sources/tev-000089.yaml
+++ b/docs/data/sources/tev-000089.yaml
@@ -1,0 +1,34 @@
+source_id: 89
+
+common_name: HESS J1641-463
+gamma_names: [HESS J1641-463]
+fermi_names: []
+other_names:
+- SNR G338.5+0.1
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2012-10
+
+tevcat_id: 243
+tevcat2_id: oeIIrE
+tevcat_name: TeV J1641-463
+
+tgevcat_id: 89
+tgevcat_name: TeV J1641-4618
+
+pos:
+  simbad_id: HESS J1641-463
+  ra: 250.25708
+  dec: -46.30306
+
+reference_ids:
+- 2013arXiv1303.0979O
+- 2014ApJ...794L..16L
+- 2014ApJ...794L...1A
+- 2015ApJ...812...32T
+- 2015arXiv150908310O
+- 2016arXiv161005444L

--- a/docs/data/sources/tev-000090.yaml
+++ b/docs/data/sources/tev-000090.yaml
@@ -1,0 +1,36 @@
+source_id: 90
+
+common_name: Westerlund 1
+gamma_names: [HESS J1646-458]
+fermi_names: []
+other_names:
+- Wd 1
+- CXOU J164710.2 - 455216
+- 4U 1642-45
+- PSR J1648-4611
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2009-06
+
+tevcat_id: 186
+tevcat2_id: Lv6nKy
+tevcat_name: TeV J1647-458
+
+tgevcat_id: 90
+tgevcat_name: TeV J1646-4549
+
+pos:
+  simbad_id: HESS J1646–458
+  ra: 251.5
+  dec: -45.8
+
+reference_ids:
+- 2010ASPC..422..265O
+- 2010ApJ...713L..45L
+- 2012A&A...537A.114A
+- 2013MNRAS.434.2289O
+- 2013PASJ...65...64S

--- a/docs/data/sources/tev-000091.yaml
+++ b/docs/data/sources/tev-000091.yaml
@@ -1,0 +1,40 @@
+source_id: 91
+
+common_name: Markarian 501
+gamma_names: [VER J1653+397]
+fermi_names: []
+other_names:
+- Mrk 501
+
+where: egal
+classes: [hbl]
+
+discoverer: whipple
+seen_by: [whipple, hegra, magic, veritas, hawc]
+discovery_date: 1996-01
+
+tevcat_id: 76
+tevcat2_id: FItw4l
+tevcat_name: TeV J1653+397
+
+tgevcat_id: 91
+tgevcat_name: TeV J1653+3945
+
+pos:
+  simbad_id: Markarian 501
+  ra: 253.4675695
+  dec: 39.760169139
+
+reference_ids:
+- 1996ApJ...456L..83Q
+- 1999A&A...342...69A
+- 2001ApJ...546..898A
+- 2001A&A...366...62A
+- 2008JPhG...35f5202G
+- 2009ApJ...705.1624A
+- 2011ApJ...727..129A
+- 2011ApJ...729....2A
+- 2012ApJ...758....2B
+- 2015A&A...573A..50A
+- 2015ApJ...812...65F
+- 2017A%26A...603A..31A

--- a/docs/data/sources/tev-000092.yaml
+++ b/docs/data/sources/tev-000092.yaml
@@ -1,0 +1,29 @@
+source_id: 92
+
+common_name: HESS J1702-420
+gamma_names: [HESS J1702-420]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2006-01
+
+tevcat_id: 108
+tevcat2_id: B41Y7y
+tevcat_name: TeV J1702-420
+
+tgevcat_id: 92
+tgevcat_name: TeV J1702-4200
+
+pos:
+  simbad_id: HESS J1702-420
+  ra: 255.68333
+  dec: -42.01583
+
+reference_ids:
+- 2006ApJ...636..777A
+- 2008A&A...477..353A

--- a/docs/data/sources/tev-000093.yaml
+++ b/docs/data/sources/tev-000093.yaml
@@ -1,0 +1,32 @@
+source_id: 93
+
+common_name: HESS J1708-410
+gamma_names: [HESS J1708-410]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2006-01
+
+tevcat_id: 109
+tevcat2_id: xGSgEi
+tevcat_name: TeV J1708-410
+
+tgevcat_id: 93
+tgevcat_name: TeV J1708-4105
+
+pos:
+  simbad_id: HESS J1708-410
+  ra: 257.1
+  dec: -41.09
+
+reference_ids:
+- 2006ApJ...636..777A
+- 2008A&A...477..353A
+- 2009ApJ...707.1717V
+- 2011ICRC....6..202T
+- 2011arXiv1111.1634T

--- a/docs/data/sources/tev-000094.yaml
+++ b/docs/data/sources/tev-000094.yaml
@@ -1,0 +1,34 @@
+source_id: 94
+
+common_name: HESS J1708-443
+gamma_names: [HESS J1708-443]
+fermi_names: []
+other_names:
+- PSR B1706-44
+- G343.1-2.3
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess, cangaroo]
+discovery_date: 2009-07
+
+tevcat_id: 191
+tevcat2_id: jrf7QE
+tevcat_name: TeV J1708-443
+
+tgevcat_id: 94
+tgevcat_name: TeV J1708-4420
+
+pos:
+  simbad_id: HESS J1708-443
+  ra: 257.0
+  dec: -44.3
+
+reference_ids:
+- 2009ApJ...703.1725E
+- 2009ApJ...702..631Y
+- 2009arXiv0906.5574H
+- 2011A&A...528A.143H
+- 2013ApJ...773...77A

--- a/docs/data/sources/tev-000095.yaml
+++ b/docs/data/sources/tev-000095.yaml
@@ -1,0 +1,38 @@
+source_id: 95
+
+common_name: CTB 37B
+gamma_names: [HESS J1713-381]
+fermi_names: []
+other_names:
+- SNR G348.7+0.3
+- CXOU J171405.7-381031
+
+where: gal
+classes: [snr]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2006-01
+
+tevcat_id: 110
+tevcat2_id: QYavG5
+tevcat_name: TeV J1713-382
+
+tgevcat_id: 95
+tgevcat_name: TeV J1713-3811
+
+pos:
+  simbad_id: CTB 37B
+  ra: 258.42921
+  dec: -38.17011
+
+reference_ids:
+- 2006ApJ...636..777A
+- 2008A&A...486..829A
+- 2010ApJ...710..941H
+- 2010ApJ...725.1384H
+- 2011RAA....11..625H
+- 2012MNRAS.421.2593T
+- 2013MNRAS.434.2748C
+- 2015APh....65...80M
+- 2016ApJ...817...64X

--- a/docs/data/sources/tev-000096.yaml
+++ b/docs/data/sources/tev-000096.yaml
@@ -1,0 +1,33 @@
+source_id: 96
+
+common_name: RX J1713.7-3946
+gamma_names:
+- HESS J1713-397
+fermi_names: []
+other_names:
+- SNR G347.3-00.5
+
+where: gal
+classes: [snr]
+
+discoverer: cangaroo
+seen_by: [cangaroo, hess]
+discovery_date: 2000-02
+
+tevcat_id: 84
+tevcat2_id: Q6SXwo
+tevcat_name: TeV J1713-397
+
+tgevcat_id: 96
+tgevcat_name: TeV J1713-3945
+
+pos:
+  simbad_id: RX J1713.7-3946
+  ra: 258.1125
+  dec: -39.6867
+
+reference_ids:
+- 2004Natur.432...75A
+- 2006A&A...449..223A
+- 2007A&A...464..235A
+- 2016arXiv160908671H

--- a/docs/data/sources/tev-000097.yaml
+++ b/docs/data/sources/tev-000097.yaml
@@ -1,0 +1,38 @@
+source_id: 97
+
+common_name: CTB 37A
+gamma_names: [HESS J1714-385]
+fermi_names: []
+other_names:
+- SNR G348.5+0.1
+- CXOU J171419.8-383023
+
+where: gal
+classes: [snr, mc]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-11
+
+tevcat_id: 158
+tevcat2_id: Mk4fht
+tevcat_name: TeV J1714-385
+
+tgevcat_id: 97
+tgevcat_name: TeV J1714-3834
+
+pos:
+  simbad_id: CTB 37A
+  ra: 258.643
+  dec: -38.549
+
+reference_ids:
+- 2008A&A...490..685A
+- 2010ApJ...717..372C
+- 2012MNRAS.421..935L
+- 2012ApJ...761..133Y
+- 2012MNRAS.421.2593T
+- 2013A&A...553A..34D
+- 2013MNRAS.434.2188M
+- 2013AdSpR..51..247B
+

--- a/docs/data/sources/tev-000098.yaml
+++ b/docs/data/sources/tev-000098.yaml
@@ -1,0 +1,31 @@
+source_id: 98
+
+common_name: SNR G349.7+0.2
+gamma_names: [HESS J1718-374]
+fermi_names: []
+other_names:
+- SNR G349.7+00.2
+
+where: gal
+classes: [snr, mc]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2013-07
+
+tevcat_id: 250
+tevcat2_id: D5Wki5
+tevcat_name: TeV J1718-374
+
+tgevcat_id: 98
+tgevcat_name: TeV J1717-3726
+
+pos:
+  simbad_id: SNR G349.7+0.2
+  ra: 259.496
+  dec: -37.427
+
+reference_ids:
+- 2015A&A...574A.100H
+- 2014ApJ...783L...2T
+- 2015ApJ...804..124E

--- a/docs/data/sources/tev-000099.yaml
+++ b/docs/data/sources/tev-000099.yaml
@@ -1,0 +1,29 @@
+source_id: 99
+
+common_name: HESS J1718-385
+gamma_names: [HESS J1718-385]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2007-09
+
+tevcat_id: 154
+tevcat2_id: iq0QXk
+tevcat_name: TeV J1718-385
+
+tgevcat_id: 99
+tgevcat_name: TeV J1718-3833
+
+pos:
+  simbad_id: HESS J1718-385
+  ra: 259.5292
+  dec: -38.55
+
+reference_ids:
+- 2007A&A...476L..25H
+- 2007A&A...472..489A

--- a/docs/data/sources/tev-000100.yaml
+++ b/docs/data/sources/tev-000100.yaml
@@ -1,0 +1,29 @@
+source_id: 100
+
+common_name: H 1722+119
+gamma_names: []
+fermi_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2013-05
+
+tevcat_id: 246
+tevcat2_id: neQBRF
+tevcat_name: TeV 1725+118
+
+tgevcat_id: 100
+tgevcat_name: TeV J1725+1152
+
+pos:
+  simbad_id: H 1722+119
+  ra: 261.268086958
+  dec: 11.870963556
+
+reference_ids:
+- http://www.astronomerstelegram.org/?read=5080
+- 2016arXiv160306523A

--- a/docs/data/sources/tev-000101.yaml
+++ b/docs/data/sources/tev-000101.yaml
@@ -1,0 +1,36 @@
+source_id: 101
+
+common_name: 1ES 1727+502
+gamma_names: [VER J1728+502]
+fermi_names: []
+other_names:
+- OT546
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic, veritas]
+discovery_date: 2011-11
+
+tevcat_id: 232
+tevcat2_id: 9xaXCk
+tevcat_name: TeV J1728+502
+
+tgevcat_id: 101
+tgevcat_name: TeV J1728+5013
+
+pos:
+  simbad_id: 1ES 1727+502
+  ra: 262.07759958
+  dec: 50.219575
+
+reference_ids:
+- http://www.astronomerstelegram.org/?read=3774
+- 2013arXiv1308.0287D
+- 2014A&A...563A..90A
+- 2015arXiv150805551C
+- 2015arXiv150807251B
+- 2015ApJ...808..110A
+- 2015arXiv150103554C
+- 2015ApJ...808..110A

--- a/docs/data/sources/tev-000102.yaml
+++ b/docs/data/sources/tev-000102.yaml
@@ -1,0 +1,29 @@
+source_id: 102
+
+common_name: HESS J1729-345
+gamma_names: [HESS J1729-345]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2011-05
+
+tevcat_id: 224
+tevcat2_id: UnsKSi
+tevcat_name: TeV J1729-345
+
+tgevcat_id: 102
+tgevcat_name: TeV J1729-3432
+
+pos:
+  simbad_id: HESS J1729-345
+  ra: 262.25
+  dec: -34.5
+
+reference_ids:
+- 2011A&A...531A..81H
+- 2015arXiv150306717M

--- a/docs/data/sources/tev-000103.yaml
+++ b/docs/data/sources/tev-000103.yaml
@@ -1,0 +1,40 @@
+source_id: 103
+
+common_name: HESS J1731-347
+gamma_names: [HESS J1731-347]
+fermi_names: []
+other_names:
+- SNR G353.6-0.7
+
+where: gal
+classes: [snr]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2007-07
+
+tevcat_id: 141
+tevcat2_id: mrGXwA
+tevcat_name: TeV J1732-347
+
+tgevcat_id: 103
+tgevcat_name: TeV J1732-3445
+
+pos:
+  simbad_id: HESS J1731-347
+  ra: 262.97917
+  dec: -34.71
+
+reference_ids:
+- 2008ApJ...679L..85T
+- 2008A&A...477..353A
+- 2010ApJ...710..941H
+- 2010ApJ...712..790T
+- 2011A&A...531A..81H
+- 2012ApJ...756..149B
+- 2013A&A...556A..41K
+- 2013MNRAS.434.2748C
+- 2015A&A...573A..53K
+- 2015MNRAS.454.2668O
+- 2015A&A...580A..74A
+- 2015arXiv150306717M

--- a/docs/data/sources/tev-000104.yaml
+++ b/docs/data/sources/tev-000104.yaml
@@ -1,0 +1,30 @@
+source_id: 104
+
+common_name: HESS J1741-302
+gamma_names: [HESS J1741-302]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-07
+
+tevcat_id: 189
+tevcat2_id: JPcqWZ
+tevcat_name: TeV J1741-301
+
+tgevcat_id: 104
+tgevcat_name: TeV J1741-3012
+
+pos:
+  simbad_id: HESS J1741-302
+  ra: 265.25
+  dec: -30.2
+
+reference_ids:
+- 2008AIPC.1085..249T
+- 2016ApJ...816...52H
+- 2016MNRAS.tmp....7H

--- a/docs/data/sources/tev-000105.yaml
+++ b/docs/data/sources/tev-000105.yaml
@@ -1,0 +1,30 @@
+source_id: 105
+
+common_name: 1ES 1741+196
+gamma_names: [VER J1744+195]
+fermi_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic, veritas]
+discovery_date: 2011-08
+
+tevcat_id: 225
+tevcat2_id: Y4DogE
+tevcat_name: TeV J1743+196
+
+tgevcat_id: 105
+tgevcat_name: TeV J1743+1935
+
+pos:
+  simbad_id: 1ES 1741+196
+  ra: 265.99096917
+  dec: 19.58583806
+
+reference_ids:
+- 2011ICRC....8..169B
+- 2013arXiv1308.0287D
+- 2016MNRAS.459.2550A

--- a/docs/data/sources/tev-000106.yaml
+++ b/docs/data/sources/tev-000106.yaml
@@ -1,0 +1,38 @@
+source_id: 106
+
+common_name: Galactic Centre
+gamma_names: [HESS J1745-290, VER J1745-290]
+fermi_names: []
+other_names:
+- Sgr A*
+- Sagittarius A*
+
+where: gal
+classes: [unid]
+
+discoverer: cangaroo
+seen_by: [cangaroo, whipple, hess, veritas, magic]
+discovery_date: 2004-05
+
+tevcat_id: 81
+tevcat2_id: UvKbRe
+tevcat_name: TeV J1745-290
+
+tgevcat_id: 106
+tgevcat_name: TeV J1745-2900
+
+pos:
+  simbad_id: Galactic Centre
+  ra: 266.416833
+  dec: -29.007806
+
+reference_ids:
+- 2004A&A...425L..13A
+- 2006PhRvL..97v1102A
+- 2009A&A...503..817A
+- 2010MNRAS.402.1877A
+- 2014ApJ...790..149A
+- 2015arXiv150903425P
+- 2015arXiv150806311S
+- 2016Natur.531..476H
+- 2016ApJ...821..129A

--- a/docs/data/sources/tev-000107.yaml
+++ b/docs/data/sources/tev-000107.yaml
@@ -1,0 +1,34 @@
+source_id: 107
+
+common_name: Galactic Centre ridge
+gamma_names: []
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2006-02
+
+tevcat_id: 121
+tevcat2_id: PehQOM
+tevcat_name: TeV J1745-290d
+
+tgevcat_id: 107
+tgevcat_name: TeV J1745-2900
+
+reference_ids:
+- 2006Natur.439..695A
+- 2010MNRAS.402.1877A
+- 2016ApJ...821..129A
+
+pos:
+  simbad_id: Galactic Centre
+  ra: 266.416833
+  dec: -29.007806
+
+notes: |
+  TODO: should we put this as a source?
+  Or have it be part of the Galactic diffuse emission?

--- a/docs/data/sources/tev-000108.yaml
+++ b/docs/data/sources/tev-000108.yaml
@@ -1,0 +1,39 @@
+source_id: 108
+
+common_name: HESS J1745-303
+gamma_names: []
+fermi_names: []
+other_names:
+- G359.1-0.5
+
+where: gal
+classes: [unid, snr, mc]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2006-01
+
+tevcat_id: 111
+tevcat2_id: Gmuzgm
+tevcat_name: TeV J1745-303
+
+tgevcat_id: 108
+tgevcat_name: TeV J1745-3022
+
+pos:
+  simbad_id: HESS J1745-303
+  ra: 266.297
+  dec: -30.199
+
+reference_ids:
+- 2006ApJ...636..777A
+- 2008A&A...483..509A
+- 2009ApJ...691.1854B
+- 2011arXiv1111.1634T
+- 2011ICRC....6..202T
+- 2011ApJ...735..115H
+- 2012AIPC.1505..265E
+- 2012ApJ...761..133Y
+- 2015APh....65...80M
+- 2016MNRAS.457.4262H
+

--- a/docs/data/sources/tev-000109.yaml
+++ b/docs/data/sources/tev-000109.yaml
@@ -1,0 +1,35 @@
+source_id: 109
+
+common_name: Terzan 5
+gamma_names: [HESS J1747-248]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid, gc]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2011-07
+
+tevcat_id: 234
+tevcat2_id: xhmRbS
+tevcat_name: TeV J1747-248
+
+tgevcat_id: 109
+tgevcat_name: TeV J1747-2448
+
+pos:
+  simbad_id: Terzan 5
+  ra: 267.020833
+  dec: -24.78
+
+reference_ids:
+- 2006ApJ...636..777A
+- 2011A&A...531L..18H
+- 2011ICRC....7..119D
+- 2011A&A...533L...5D
+- 2013A&A...551A..26H
+- 2013MmSAI..84..236M
+- 2013MNRAS.432.3462Z
+- 2014MNRAS.445.2842B

--- a/docs/data/sources/tev-000110.yaml
+++ b/docs/data/sources/tev-000110.yaml
@@ -1,0 +1,34 @@
+source_id: 110
+
+common_name: SNR G0.9+0.1
+gamma_names: [HESS J1747-281, VER J1747-281]
+fermi_names: []
+other_names:
+- SNR G000.9+00.1
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess, veritas]
+discovery_date: 2005-03
+
+tevcat_id: 112
+tevcat2_id: jvz6ag
+tevcat_name: TeV J1747-281
+
+tgevcat_id: 110
+tgevcat_name: TeV J1747-2809
+
+pos:
+  simbad_id: SNR G0.9+0.1
+  ra: 266.825
+  dec: -28.15
+
+reference_ids:
+- 1987ApJ...314..203H
+- 2005A&A...432L..25A
+- 2008A&A...487.1033D
+- 2010A&A...515A..20F
+- 2015arXiv150806311S
+- 2016ApJ...821..129A

--- a/docs/data/sources/tev-000111.yaml
+++ b/docs/data/sources/tev-000111.yaml
@@ -1,0 +1,31 @@
+source_id: 111
+
+common_name: HESS J1800-240A
+gamma_names: [HESS J1800-240A]
+other_names: []
+
+where: gal
+classes: [snr, mc]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-04
+
+tevcat_id: 163
+tevcat2_id: sPYizN
+tevcat_name: TeV J1801-239
+
+tgevcat_id: 111
+tgevcat_name: TeV J1800-2359
+
+pos:
+  simbad_id: HESS J1800-240A
+  ra: 270.4917
+  dec: -23.9617
+
+reference_ids:
+- 2008A&A...481..401A
+- 2010ApJ...718..348A
+
+notes: |
+  tgevcat_name: TeV J1800-2359 represents both HESS J1800-240A and HESS J1800-240B.

--- a/docs/data/sources/tev-000112.yaml
+++ b/docs/data/sources/tev-000112.yaml
@@ -1,0 +1,48 @@
+source_id: 112
+
+common_name: W28
+gamma_names: [HESS J1801-233]
+fermi_names: []
+other_names:
+- W 28
+- SNR G6.4-0.1
+- SNR G006.4-00.1
+- GRO J1801-2320
+
+where: gal
+classes: [snr, mc]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-04
+
+tevcat_id: 162
+tevcat2_id: jcVLu0
+tevcat_name: TeV J1801-233
+
+tgevcat_id: 112
+tgevcat_name: TeV J1801-2320
+
+pos:
+  simbad_id: HESS J1801-233
+  ra: 270.34458
+  dec: -23.28889
+
+reference_ids:
+- 1997ApJ...489..143C
+- 2004ASPC..317...59M
+- 2008AIPC.1085..104F
+- 2008A&A...481..401A
+- 2009ApJ...707L.179F
+- 2010MNRAS.407...94M
+- 2010ApJ...718..348A
+- 2010A&A...516L..11G
+- 2012MNRAS.421..935L
+- 2012A&A...543L...9N
+- 2012ApJ...761..133Y
+- 2013MNRAS.429.1643N
+- 2013A&A...553A..34D
+- 2015APh....65...80M
+- 2015arXiv150306580G
+- 2016arXiv161000865M
+- 2016MNRAS.462..532M

--- a/docs/data/sources/tev-000113.yaml
+++ b/docs/data/sources/tev-000113.yaml
@@ -1,0 +1,38 @@
+source_id: 113
+
+common_name: HESS J1804-216
+gamma_names: [HESS J1804-216]
+fermi_names: []
+other_names:
+- G8.7-0.1
+- W30
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2005-03
+
+tevcat_id: 113
+tevcat2_id: y1kNQO
+tevcat_name: TeV J1804-217
+
+tgevcat_id: 113
+tgevcat_name: TeV J1804-2143
+
+pos:
+  simbad_id: HESS J1804-216
+  ra: 271.12375
+  dec: -21.732556
+
+reference_ids:
+- 2005Sci...307.1938A
+- 2006ApJ...636..777A
+- 2008ApJ...683..957H
+- 2010ApJ...717..372C
+- 2012ApJ...744...80A
+- 2012ApJ...761..133Y
+- 2013ApJ...773...77A
+- 2013ApJ...766...29L
+- 2015APh....65...80M

--- a/docs/data/sources/tev-000114.yaml
+++ b/docs/data/sources/tev-000114.yaml
@@ -1,0 +1,32 @@
+source_id: 114
+
+common_name: HESS J1808-204
+gamma_names: [HESS J1808-204]
+fermi_names: []
+other_names:
+- SGR 1806-20
+- LBV 1806-20
+- C1 1806-20
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2012-07
+
+tevcat_id: 242
+tevcat2_id: Ere9PS
+tevcat_name: TeV J1808-204
+
+tgevcat_id: 114
+tgevcat_name: TeV J1808-2026
+
+pos:
+  simbad_id: HESS J1808-204
+  ra: 272.0
+  dec: -20.4
+
+reference_ids:
+- https://www.mpi-hd.mpg.de/hd2012/pages/presentations/Rowell.pdf
+- 2016arXiv160605404A

--- a/docs/data/sources/tev-000115.yaml
+++ b/docs/data/sources/tev-000115.yaml
@@ -1,0 +1,32 @@
+source_id: 115
+
+common_name: HESS J1809-193
+gamma_names: [HESS J1809-193]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2007-09
+
+tevcat_id: 155
+tevcat2_id: OWsjG1
+tevcat_name: TeV J1810-193
+
+tgevcat_id: 115
+tgevcat_name: TeV J1810-1918
+
+pos:
+  simbad_id: HESS J1809-193
+  ra: 272.6292
+  dec: -19.3
+
+reference_ids:
+- 2007A&A...472..489A
+- 2008AIPC.1085..285R
+- 2010PASJ...62..179A
+- 2014ApJ...796...34R
+- 2016A&A...587A..71C

--- a/docs/data/sources/tev-000116.yaml
+++ b/docs/data/sources/tev-000116.yaml
@@ -1,0 +1,43 @@
+source_id: 116
+
+common_name: HESS J1813-178
+gamma_names: [HESS J1813-178]
+fermi_names: []
+other_names:
+- G12.82-0.02
+- PSR J1813-1749
+- CXOU J181335.1-174957
+- IGR J18135-1751
+- W33
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess, magic]
+discovery_date: 2005-03
+
+tevcat_id: 114
+tevcat2_id: Unhlxa
+tevcat_name: TeV J1813-178
+
+tgevcat_id: 116
+tgevcat_name: TeV J1813-1750
+
+pos:
+  simbad_id: HESS J1813-178
+  ra: 273.36292
+  dec: -17.84889
+
+reference_ids:
+- 2005Sci...307.1938A
+- 2006ApJ...637L..41A
+- 2006ApJ...636..777A
+- 2007A&A...470..249F
+- 2008ApJ...683L.155M
+- 2008A&A...485..195D
+- 2009ApJ...700L.158G
+- 2010ApJ...718..467F
+- 2012ApJ...753L..14H
+- 2013ApJ...773...77A
+- 2015APh....65...80M

--- a/docs/data/sources/tev-000117.yaml
+++ b/docs/data/sources/tev-000117.yaml
@@ -1,0 +1,30 @@
+source_id: 117
+
+common_name: SNR G15.4+0.1
+gamma_names: [HESS J1818-154]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [pwn, snr]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2011-12
+
+tevcat_id: 233
+tevcat2_id: SxYdrN
+tevcat_name: TeV J1818-154
+
+tgevcat_id: 117
+tgevcat_name: TeV J1818-1528
+
+pos:
+  simbad_id: SNR G15.4+0.1
+  ra: 274.5
+  dec: -15.45
+
+reference_ids:
+- 2011ICRC....7..248H
+- 2013A&A...557L..15C
+- 2014A&A...562A..40H

--- a/docs/data/sources/tev-000118.yaml
+++ b/docs/data/sources/tev-000118.yaml
@@ -1,0 +1,41 @@
+source_id: 118
+
+common_name: HESS J1825-137
+gamma_names: [HESS J1825-137, 1HWC J1825-133]
+fermi_names: []
+other_names:
+- PSR J1826-1334
+- PSR B1823-13
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess, hawc]
+discovery_date: 2005-03
+
+tevcat_id: 115
+tevcat2_id: xnwQAv
+tevcat_name: TeV J1826-137
+
+tgevcat_id: 118
+tgevcat_name: TeV J1825-1350
+
+pos:
+  simbad_id: HESS J1825-137
+  ra: 276.55441
+  dec: -13.58004
+
+reference_ids:
+- 2005Sci...307.1938A
+- 2005A&A...442L..25A
+- 2006ApJ...636..777A
+- 2006A&A...460..365A
+- 2008ApJ...675..683P
+- 2009PASJ...61S.189U
+- 2011ApJ...738...42G
+- 2011ApJ...742...62V
+- 2012arXiv1202.1455M
+- 2013ApJ...773...77A
+- 2016ApJ...817....3A
+- 2016MNRAS.458.2813V

--- a/docs/data/sources/tev-000119.yaml
+++ b/docs/data/sources/tev-000119.yaml
@@ -1,0 +1,30 @@
+source_id: 119
+
+common_name: LS 5039
+gamma_names: [HESS J1826-148]
+fermi_names: []
+other_names:
+- RX J1826.2-1450
+
+where: gal
+classes: [bin]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2005-07
+
+tevcat_id: 96
+tevcat2_id: xKaTtF
+tevcat_name: TeV J1826-148
+
+tgevcat_id: 119
+tgevcat_name: TeV J1826-1449
+
+pos:
+  simbad_id: LS 5039
+  ra: 276.5627375
+  dec: -14.8484056
+
+reference_ids:
+- 2005Sci...309..746A
+- 2006A&A...460..743A

--- a/docs/data/sources/tev-000120.yaml
+++ b/docs/data/sources/tev-000120.yaml
@@ -1,0 +1,29 @@
+source_id: 120
+
+common_name: HESS J1831-098
+gamma_names: [HESS J1831-098]
+fermi_names: []
+other_names:
+- PSR J1831-952
+
+where: gal
+classes: [unid, pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2011-10
+
+tevcat_id: 231
+tevcat2_id: buLRDe
+tevcat_name: TeV J1831-099
+
+tgevcat_id: 120
+tgevcat_name: TeV J1831-0954
+
+pos:
+  simbad_id: HESS J1831-098
+  ra: 277.85
+  dec: -9.9
+
+reference_ids:
+- 2011ICRC....7..244S

--- a/docs/data/sources/tev-000121.yaml
+++ b/docs/data/sources/tev-000121.yaml
@@ -1,0 +1,33 @@
+source_id: 121
+
+common_name: HESS J1832-093
+gamma_names: [HESS J1832-093]
+fermi_names: []
+other_names:
+- SNR G22.7-0.2
+
+where: gal
+classes: [bin, unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2011-10
+
+tevcat_id: 230
+tevcat2_id: 1aPLDl
+tevcat_name: TeV J1832-093
+
+tgevcat_id: 121
+tgevcat_name: TeV J1832-0922
+
+pos:
+  simbad_id: HESS J1832-093
+  ra: 278.188175
+  dec: -9.3651528
+
+reference_ids:
+- 2011arXiv1110.6890L
+- 2013arXiv1308.0475L
+- 2015MNRAS.446.1163H
+- 2016arXiv161003264B
+- 2016MNRAS.457.1753E

--- a/docs/data/sources/tev-000122.yaml
+++ b/docs/data/sources/tev-000122.yaml
@@ -1,0 +1,36 @@
+source_id: 122
+
+common_name: HESS J1833-105
+gamma_names: [HESS J1833-105]
+fermi_names: []
+other_names:
+- G21.5-0.9
+- PSR J1833-1034
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2007-10
+
+tevcat_id: 140
+tevcat2_id: EmvcSG
+tevcat_name: TeV J1833-105
+
+tgevcat_id: 122
+tgevcat_name: TeV J1833-1033
+
+pos:
+  simbad_id: HESS J1833-105
+  ra: 278.25
+  dec: -10.5
+
+reference_ids:
+- 2008ICRC....2..823D
+- 2008MNRAS.391L..54T
+- 2009MNRAS.393..527D
+- 2011MNRAS.412.1221B
+- 2012ASPC..466..167K
+- 2016MNRAS.460.4135P
+- https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf

--- a/docs/data/sources/tev-000123.yaml
+++ b/docs/data/sources/tev-000123.yaml
@@ -1,0 +1,43 @@
+source_id: 123
+
+common_name: HESS J1834-087
+gamma_names:
+- HESS J1834-087
+- 1HWC J1836-090c
+fermi_names: []
+other_names:
+- W41
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess, magic, hawc]
+discovery_date: 2005-03
+
+tevcat_id: 116
+tevcat2_id: 4xiQfb
+tevcat_name: TeV J1834-087
+
+tgevcat_id: 123
+tgevcat_name: TeV J1834-0845
+
+pos:
+  simbad_id: HESS J1834-087
+  ra: 278.715833
+  dec: -8.743944
+
+reference_ids:
+- 2005Sci...307.1938A
+- 2006ApJ...643L..53A
+- 2006ApJ...636..777A
+- 2007ApJ...657L..25T
+- 2009ApJ...691.1707M
+- 2010cosp...38.2801M
+- 2011ApJ...735...33M
+- 2012MNRAS.421..935L
+- 2012ApJ...761..133Y
+- 2013ApJ...773L..19F
+- 2013ApJ...773...77A
+- 2015APh....65...80M
+- 2016ApJ...817....3A

--- a/docs/data/sources/tev-000124.yaml
+++ b/docs/data/sources/tev-000124.yaml
@@ -1,0 +1,35 @@
+source_id: 124
+
+common_name: HESS J1837-069
+gamma_names: [HESS J1837-069, 1HWC J1838-060, 1HWC J1836-074c]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess, hawc]
+discovery_date: 2005-03
+
+tevcat_id: 117
+tevcat2_id: giVWlK
+tevcat_name: TeV J1837-069
+
+tgevcat_id: 124
+tgevcat_name: TeV J1837-0656
+
+pos:
+  simbad_id: HESS J1837-069
+  ra: 279.42792
+  dec: -6.9275
+
+reference_ids:
+- 2005Sci...307.1938A
+- 2006ApJ...636..777A
+- 2008ApJ...681..515G
+- 2009PASJ...61S.183A
+- 2012arXiv1202.1455M
+- 2013ApJ...773...77A
+- 2014PASJ...66...19F
+- 2016ApJ...817....3A

--- a/docs/data/sources/tev-000125.yaml
+++ b/docs/data/sources/tev-000125.yaml
@@ -1,0 +1,36 @@
+source_id: 125
+
+common_name: HESS J1841-055
+gamma_names: [HESS J1841-055, ARGO J1839-0627, 1HWC J1838-060]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess, argo, hawc]
+discovery_date: 2007-07
+
+tevcat_id: 142
+tevcat2_id: amNIwH
+tevcat_name: TeV J1840-055
+
+tgevcat_id: 125
+tgevcat_name: TeV J1840-0533
+
+pos:
+  simbad_id: HESS J1841-055
+  ra: 280.22917
+  dec: -5.55
+
+reference_ids:
+- 2008A&A...477..353A
+- 2009ApJ...697.1194S
+- 2011arXiv1111.1634T
+- 2011ICRC....6..202T
+- 2013ApJ...779...27B
+- 2013ApJ...773...77A
+- 2013arXiv1303.1258T
+- 2015AdSpR..55.2493N
+- 2016ApJ...817....3A

--- a/docs/data/sources/tev-000126.yaml
+++ b/docs/data/sources/tev-000126.yaml
@@ -1,0 +1,30 @@
+source_id: 126
+
+common_name: HESS J1843-033
+gamma_names: [HESS J1843-033, ARGO J1841-0332 1HWC J1844-031c]
+fermi_names: []
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess, argo, hawc]
+discovery_date: 2008-07
+
+tevcat_id: 190
+tevcat2_id: DTC72E
+tevcat_name: TeV J1843-030
+
+tgevcat_id: 126
+tgevcat_name: TeV J1843-0318
+
+pos:
+  simbad_id: HESS J1843-033
+  ra: 280.75
+  dec: -3.3
+
+reference_ids:
+- 2008ICRC....2..579H
+- 2013ApJ...779...27B
+- 2016ApJ...817....3A

--- a/docs/data/sources/tev-000127.yaml
+++ b/docs/data/sources/tev-000127.yaml
@@ -1,0 +1,32 @@
+source_id: 127
+
+common_name: HESS J1846-029
+gamma_names: [HESS J1846-029]
+fermi_names: []
+other_names:
+- Kes 75
+- SNR G29.7-0.3
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess, hawc]
+discovery_date: 2007-10
+
+tevcat_id: 167
+tevcat2_id: Ipmg1A
+tevcat_name: TeV J1846-029
+
+tgevcat_id: 127
+tgevcat_name: TeV J1846-0258
+
+pos:
+  simbad_id: HESS J1846-029
+  ra: 281.5
+  dec: -2.9
+
+reference_ids:
+- 2008ICRC....2..823D
+- 2008A&A...480L..25L
+- 2016ApJ...817....3A

--- a/docs/data/sources/tev-000128.yaml
+++ b/docs/data/sources/tev-000128.yaml
@@ -1,0 +1,33 @@
+source_id: 128
+
+common_name: HESS J1848-018
+gamma_names: [HESS J1848-018, 1HWC J1849-017c]
+fermi_names: []
+other_names:
+- WR121a
+- W43
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-07
+
+tevcat_id: 187
+tevcat2_id: hcE3Ou
+tevcat_name: TeV J1848-017
+
+tgevcat_id: 128
+tgevcat_name: TeV J1848-0147
+
+pos:
+  simbad_id: HESS J1848-018
+  ra: 282.12
+  dec: -1.792
+
+reference_ids:
+- 2008AIPC.1085..372C
+- 2011MmSAI..82..739L
+- 2013ApJ...773...77A
+- 2016ApJ...817....3A

--- a/docs/data/sources/tev-000129.yaml
+++ b/docs/data/sources/tev-000129.yaml
@@ -1,0 +1,33 @@
+source_id: 129
+
+common_name: HESS J1849-000
+gamma_names: [HESS J1849-000]
+fermi_names: []
+other_names:
+- IGR J18490-0000
+- 3C 391
+- PSR J1849-0001
+
+where: gal
+classes: [pwn]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-07
+
+tevcat_id: 188
+tevcat2_id: 8nWF6I
+tevcat_name: TeV J1849-000
+
+tgevcat_id: 129
+tgevcat_name: TeV J1849-0001
+
+pos:
+  simbad_id: HESS J1849-000
+  ra: 282.257625
+  dec: -0.021972
+
+reference_ids:
+- http://www.astronomerstelegram.org/?read=3057
+- 2011ApJ...729L..16G
+- 2015APh....65...80M

--- a/docs/data/sources/tev-000130.yaml
+++ b/docs/data/sources/tev-000130.yaml
@@ -1,0 +1,28 @@
+source_id: 130
+
+common_name: HESS J1857+026
+gamma_names: [MAGIC J1857.2+0263, MAGIC J1857.6+0297, 1HWC J1857+023]
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess, magic, hawc]
+discovery_date: 2007-07
+
+tevcat_id: 143
+tevcat2_id: BDIaeo
+tevcat_name: TeV J1857+026
+
+tgevcat_id: 130
+tgevcat_name: TeV J1857+0242
+
+pos:
+  simbad_id: HESS J1857+026
+  ra: 284.29583
+  dec: 2.66667
+
+reference_ids:
+- 2008A&A...477..353A
+- 2014A&A...571A..96M

--- a/docs/data/sources/tev-000131.yaml
+++ b/docs/data/sources/tev-000131.yaml
@@ -1,0 +1,29 @@
+source_id: 131
+
+common_name: HESS J1858+020
+gamma_names: [1HWC J1857+023]
+other_names: [G35.6-0.4]
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess, hawc]
+discovery_date: 2007-07
+
+tevcat_id: 144
+tevcat2_id: KxJfNI
+tevcat_name: TeV J1858+020
+
+tgevcat_id: 131
+tgevcat_name: TeV J1858+0205
+
+pos:
+  simbad_id: HESS J1858+020
+  ra: 284.58333
+  dec: 2.09
+
+reference_ids:
+- 2008A&A...477..353A
+- 2016ApJ...817....3A
+- 2014ApJ...787..166A

--- a/docs/data/sources/tev-000132.yaml
+++ b/docs/data/sources/tev-000132.yaml
@@ -1,0 +1,30 @@
+source_id: 132
+
+common_name: MGRO J1908+06
+gamma_names: [HESS J1908+063, VER J1907+062, 1HWC J1907+062c, ARGO J1907+0627, ARGO
+    J1910+0720]
+other_names: [GeV J1907+0557, GRO J1908+0556, G40.5-0.5, 0FGL J1907.5+0602, 1AGL J1908+0613]
+
+where: gal
+classes: [unid]
+
+discoverer: milagro
+seen_by: [hess, milagro, veritas, hawc, argo]
+discovery_date: 2007-08
+
+tevcat_id: 148
+tevcat2_id: eaYOuH
+tevcat_name: TeV J1907+062
+
+tgevcat_id: 132
+tgevcat_name: TeV J1907+0613
+
+pos:
+  simbad_id: MGRO J1908+06
+  ra: 287.175
+  dec: 6.183
+
+reference_ids:
+- 2007arXiv0710.4057T
+- 2009A&A...499..723A
+- 2014ApJ...787..166A

--- a/docs/data/sources/tev-000133.yaml
+++ b/docs/data/sources/tev-000133.yaml
@@ -1,0 +1,29 @@
+source_id: 133
+
+common_name: W 49B
+gamma_names: [HESS J1911+090]
+other_names: [SNR G043.3-00.2, 0FGL J1911.0+0905, 1FGL J1910.9+0906c]
+
+where: gal
+classes: [snr, mc]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2010-12
+
+tevcat_id: 218
+tevcat2_id: tHQw4n
+tevcat_name: TeV J1911+090
+
+tgevcat_id: 133
+tgevcat_name: TeV J1911+0905
+
+pos:
+  simbad_id: W 49B
+  ra: 287.7458
+  dec: 9.1017
+
+reference_ids:
+- 2011arXiv1104.5003B
+- 2011ICRC....7..111B
+- 2016arXiv160900600H

--- a/docs/data/sources/tev-000134.yaml
+++ b/docs/data/sources/tev-000134.yaml
@@ -1,0 +1,28 @@
+source_id: 134
+
+common_name: HESS J1912+101
+gamma_names: []
+other_names: [PSR J1913+1011]
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-02
+
+tevcat_id: 157
+tevcat2_id: J26r5R
+tevcat_name: TeV J1912+101
+
+tgevcat_id: 134
+tgevcat_name: TeV J1912+1009
+
+pos:
+  simbad_id: PSR J1913+1011
+  ra: 288.3347542
+  dec: 10.1897139
+
+reference_ids:
+- 2008A&A...484..435A
+- 2016arXiv161200261G

--- a/docs/data/sources/tev-000135.yaml
+++ b/docs/data/sources/tev-000135.yaml
@@ -1,0 +1,27 @@
+source_id: 135
+
+common_name: W 51C
+gamma_names: [HESS J1923+141]
+other_names: [SNR G49.2-0.7, 0FGL J1923.0+1411]
+
+where: gal
+classes: [snr, mc]
+
+discoverer: hess
+seen_by: [hess, magic, milagro]
+discovery_date: 2008-10
+
+tevcat_id: 178
+tevcat2_id: ParXkE
+tevcat_name: TeV J1923+141
+
+tgevcat_id: 135
+tgevcat_name: TeV J1922+1411
+
+pos:
+  simbad_id: W 51C
+  ra: 290.818
+  dec: 14.145
+
+reference_ids:
+- 2012A&A...541A..13A

--- a/docs/data/sources/tev-000136.yaml
+++ b/docs/data/sources/tev-000136.yaml
@@ -1,0 +1,27 @@
+source_id: 136
+
+common_name: SNR G054.1+00.3
+gamma_names: [VER J1930+188]
+other_names: [PSR J1930+1852]
+
+where: gal
+classes: [pwn, snr]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2009-07
+
+tevcat_id: 193
+tevcat2_id: F0Luol
+tevcat_name: TeV J1930+188
+
+tgevcat_id: 136
+tgevcat_name: TeV J1930+1852
+
+pos:
+  simbad_id: SNR G054.1+00.3
+  ra: 292.6292
+  dec: 18.867
+
+reference_ids:
+- 2010ApJ...719L..69A

--- a/docs/data/sources/tev-000137.yaml
+++ b/docs/data/sources/tev-000137.yaml
@@ -1,0 +1,28 @@
+source_id: 137
+
+common_name: HESS J1943+213
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess, veritas]
+discovery_date: 2010-11
+
+tevcat_id: 214
+tevcat2_id: RdzX69
+tevcat_name: TeV J1943+213
+
+tgevcat_id: 137
+tgevcat_name: TeV J1943+2118
+
+pos:
+  simbad_id: HESS J1943+213
+  ra: 295.9792
+  dec: 21.30222
+
+reference_ids:
+- 2011A&A...529A..49H
+- 2016arXiv161005799S

--- a/docs/data/sources/tev-000138.yaml
+++ b/docs/data/sources/tev-000138.yaml
@@ -1,0 +1,33 @@
+source_id: 138
+
+common_name: 1ES 1959+650
+gamma_names: [VER J1959+651]
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic, veritas, hegra]
+discovery_date: 1999-08
+
+tevcat_id: 79
+tevcat2_id: cUkkpO
+tevcat_name: TeV J1959+651
+
+tgevcat_id: 138
+tgevcat_name: TeV J1959+6508
+
+pos:
+  simbad_id: 1ES 1959+650
+  ra: 299.99938375
+  dec: 65.14851472
+
+reference_ids:
+- 2003ApJ...583L...9H
+- 2003ICRC....5.2615T
+- 2003A&A...406L...9A
+- 2005ApJ...621..181D
+- 2006ApJ...639..761A
+- 2008ApJ...679.1029T
+- 2013ApJ...775....3A

--- a/docs/data/sources/tev-000139.yaml
+++ b/docs/data/sources/tev-000139.yaml
@@ -1,0 +1,27 @@
+source_id: 139
+
+common_name: MAGIC J2001+435
+gamma_names: []
+other_names: [1FGL J2001.1+4351, MG4 J200112+4352]
+
+where: egal
+classes: [ibl]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2010-07
+
+tevcat_id: 165
+tevcat2_id: ljNqkw
+tevcat_name: TeV J2001+438
+
+tgevcat_id: 139
+tgevcat_name: TeV J2001+4353
+
+pos:
+  simbad_id: MAGIC J2001+435
+  ra: 300.30625
+  dec: 43.884111
+
+reference_ids:
+- 2010ATel.2753....1M

--- a/docs/data/sources/tev-000140.yaml
+++ b/docs/data/sources/tev-000140.yaml
@@ -1,0 +1,29 @@
+source_id: 140
+
+common_name: PKS 2005-489
+gamma_names: [HESS J2009-488]
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2005-06
+
+tevcat_id: 100
+tevcat2_id: ObIXbg
+tevcat_name: TeV J2009-488
+
+tgevcat_id: 140
+tgevcat_name: TeV J2009-4849
+
+pos:
+  simbad_id: PKS 2005-489
+  ra: 302.355794583
+  dec: -48.831589306
+
+reference_ids:
+- 2005A&A...436L..17A
+- 2010A&A...511A..52H
+- 2011A&A...533A.110H

--- a/docs/data/sources/tev-000141.yaml
+++ b/docs/data/sources/tev-000141.yaml
@@ -1,0 +1,27 @@
+source_id: 141
+
+common_name: VER J2016+371
+gamma_names: [MGRO J2019+37]
+other_names: [CTB 87]
+
+where: gal
+classes: [pwn, snr]
+
+discoverer: veritas
+seen_by: [veritas, milagro]
+discovery_date: 2011-08
+
+tevcat_id: 228
+tevcat2_id: wbkK3X
+tevcat_name: TeV J2016+372
+
+tgevcat_id: 141
+tgevcat_name: TeV J2016+3711
+
+pos:
+  simbad_id: VER J2016+371
+  ra: 304.0076
+  dec: 37.21476
+
+reference_ids:
+- 2014ApJ...788...78A

--- a/docs/data/sources/tev-000142.yaml
+++ b/docs/data/sources/tev-000142.yaml
@@ -1,0 +1,28 @@
+source_id: 142
+
+common_name: Dragonfly
+gamma_names: [MGRO J2019+37, VER J2019+368, VER J2016+371]
+other_names: [0FGL J2020.8+3649]
+
+where: gal
+classes: [pwn, unid]
+
+discoverer: milagro
+seen_by: [milagro, veritas]
+discovery_date: 2007-03
+
+tevcat_id: 145
+tevcat2_id: RZ7qzv
+tevcat_name: TeV J2019+368
+
+tgevcat_id: 142
+tgevcat_name: TeV J2018+3642
+
+pos:
+  simbad_id: dragonfly
+  ra: 305.27252
+  dec: 36.85126
+
+reference_ids:
+- 2012ApJ...753..159A
+- 2007ApJ...658L..33A

--- a/docs/data/sources/tev-000143.yaml
+++ b/docs/data/sources/tev-000143.yaml
@@ -1,0 +1,27 @@
+source_id: 143
+
+common_name: VER J2019+368
+gamma_names: [MGRO J2019+37]
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2014-04
+
+tevcat_id: 259
+tevcat_name: TeV J2019+368
+
+tgevcat_id: 143
+tgevcat_name: TeV J2019+3648
+
+pos:
+  simbad_id: VER J2019+368
+  ra: 304.0083
+  dec: 37.19778
+
+reference_ids:
+- 2012ApJ...753..159A
+- 2014ApJ...788...78A

--- a/docs/data/sources/tev-000144.yaml
+++ b/docs/data/sources/tev-000144.yaml
@@ -1,0 +1,28 @@
+source_id: 144
+
+common_name: Gamma Cygni
+gamma_names: [VER J2019+407]
+other_names: [1FGL J2020.0+4049, SNR G78.2+2.1]
+
+where: gal
+classes: [unid]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2009-11
+
+tevcat_id: 201
+tevcat2_id: IWrXQp
+tevcat_name: TeV J2019+407
+
+tgevcat_id: 144
+tgevcat_name: TeV J2020+4045
+
+pos:
+  simbad_id: gamma cygni
+  ra: 305.557090982
+  dec: 40.256679158
+
+reference_ids:
+- 2013ApJ...770...93A
+- 2011arXiv1111.1034A

--- a/docs/data/sources/tev-000145.yaml
+++ b/docs/data/sources/tev-000145.yaml
@@ -1,0 +1,28 @@
+source_id: 145
+
+common_name: MGRO J2031+41
+gamma_names: []
+other_names: [TeV J2032+4130, TeV 2032+413, 0FGL J2032.2+4122]
+
+where: gal
+classes: [unid]
+
+discoverer: milagro
+seen_by: [milagro]
+discovery_date: 2007-08
+
+tevcat_id: 149
+tevcat2_id: 1FCN0q
+tevcat_name: TeV J2031+406
+
+tgevcat_id: 145
+tgevcat_name: TeV J2031+4040
+
+pos:
+  simbad_id: MGRO J2031+41
+  ra: 308.025
+  dec: 41.567
+
+reference_ids:
+- 2009ApJ...700L.127A
+- 2007AIPC..921..172L

--- a/docs/data/sources/tev-000146.yaml
+++ b/docs/data/sources/tev-000146.yaml
@@ -1,0 +1,30 @@
+source_id: 146
+
+common_name: TeV J2032+4130
+gamma_names: [MGRO J2031+41, VER J2031+415]
+other_names: [0FGL J2032.2+4122]
+
+where: gal
+classes: [unid]
+
+discoverer: hegra
+seen_by: [hegra, veritas, magic, milagro]
+discovery_date: 2002-10
+
+tevcat_id: 87
+tevcat2_id: 3IY6Gd
+tevcat_name: TeV J2032+415
+
+tgevcat_id: 146
+tgevcat_name: TeV J2031+4133
+
+pos:
+  simbad_id: TeV J2032+4130
+  ra: 308.025
+  dec: 41.567
+
+reference_ids:
+- 2014ApJ...783...16A
+- 2008ApJ...675L..25A
+- 2003ICRC....4.2345R
+- 2012ApJ...753..159A

--- a/docs/data/sources/tev-000147.yaml
+++ b/docs/data/sources/tev-000147.yaml
@@ -1,0 +1,34 @@
+source_id: 147
+
+common_name: PKS 2155-304
+gamma_names: [HESS J2158-302]
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: durham
+seen_by: [durham, hess, magic]
+discovery_date: 1999-06
+
+tevcat_id: 90
+tevcat2_id: nm0IZL
+tevcat_name: TeV J2158-302
+
+tgevcat_id: 147
+tgevcat_name: TeV J2158-3013
+
+pos:
+  simbad_id: PKS 2155-304
+  ra: 329.716937958
+  dec: -30.225588389
+
+reference_ids:
+- 2005A&A...442..895A
+- 2005A&A...430..865A
+- 2009ApJ...696L.150A
+- 2010A&A...520A..83H
+- 2012A&A...539A.149H
+- 2012A&A...544A..75A
+- 2013PhRvD..88j2003A
+

--- a/docs/data/sources/tev-000148.yaml
+++ b/docs/data/sources/tev-000148.yaml
@@ -1,0 +1,28 @@
+source_id: 148
+
+common_name: BL Lacertae
+gamma_names: []
+other_names: [1ES 2200+420]
+
+where: egal
+classes: [lbl]
+
+discoverer: crimea
+seen_by: [crimea, veritas, magic]
+discovery_date: 2001-04
+
+tevcat_id: 118
+tevcat2_id: iIWshp
+tevcat_name: TeV J2202+422
+
+tgevcat_id: 148
+tgevcat_name: TeV J2202+4216
+
+pos:
+  simbad_id: BL Lacertae
+  ra: 330.680380792
+  dec: 42.277772306
+
+reference_ids:
+- 2007ApJ...666L..17A
+- 2013ApJ...762...92A

--- a/docs/data/sources/tev-000149.yaml
+++ b/docs/data/sources/tev-000149.yaml
@@ -1,0 +1,29 @@
+source_id: 149
+
+common_name: SNR G106.3+02.7
+gamma_names:
+- VER J2227+608
+other_names:
+- PSR J2229+6114
+
+where: gal
+classes: [pwn, snr]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2009-07
+
+tevcat_id: 174
+tevcat2_id: gFx3Z7
+tevcat_name: TeV J2227+608
+
+tgevcat_id: 149
+tgevcat_name: TeV J2227+6052
+
+pos:
+  simbad_id: SNR G106.3+02.7
+  ra: 336.88
+  dec: 60.83
+
+reference_ids:
+- 2009ApJ...703L...6A

--- a/docs/data/sources/tev-000150.yaml
+++ b/docs/data/sources/tev-000150.yaml
@@ -1,0 +1,32 @@
+source_id: 150
+
+common_name: Boomerang PWN
+gamma_names:
+- MGRO C4
+- MGRO J2228+61
+- 0FGL J2229.0+6114
+other_names:
+- SNR G106.6+2.9
+- PSR J2229+6114
+
+where: gal
+classes: [pwn, snr]
+
+discoverer: milagro
+seen_by: [milagro]
+discovery_date: 2009-04
+
+tevcat_id: 182
+tevcat2_id: qsRoN6
+tevcat_name: TeV J2228+611
+
+tgevcat_id: 150
+tgevcat_name: TeV J2228+6110
+
+pos:
+  simbad_id: SNR G106.6+2.9
+  ra: 337.25
+  dec: 61.2
+
+reference_ids:
+- 2009ApJ...700L.127A

--- a/docs/data/sources/tev-000151.yaml
+++ b/docs/data/sources/tev-000151.yaml
@@ -1,0 +1,28 @@
+source_id: 151
+
+common_name: RGB J2243+203
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [ibl]
+
+discoverer: veritas
+seen_by: [veritas]
+discovery_date: 2014-12
+
+tevcat_id: 257
+tevcat2_id: 7IL8zC
+tevcat_name: TeV J2243+203
+
+tgevcat_id: 151
+tgevcat_name: TeV J2243+2021
+
+pos:
+  simbad_id: RGB J2243+203
+  ra: 340.978097917
+  dec: 20.351049306
+
+reference_ids:
+- 2015arXiv150806334A
+- 2014ATel.6849....1H

--- a/docs/data/sources/tev-000152.yaml
+++ b/docs/data/sources/tev-000152.yaml
@@ -1,0 +1,27 @@
+source_id: 152
+
+common_name: B3 2247+381
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: magic
+seen_by: [magic]
+discovery_date: 2010-10
+
+tevcat_id: 211
+tevcat2_id: WCU2Cw
+tevcat_name: TeV J2250+384
+
+tgevcat_id: 152
+tgevcat_name: TeV J2250+3824
+
+pos:
+  simbad_id: B3 2247+381
+  ra: 342.52395075
+  dec: 38.410332111
+
+reference_ids:
+- 2012A&A...539A.118A

--- a/docs/data/sources/tev-000153.yaml
+++ b/docs/data/sources/tev-000153.yaml
@@ -1,0 +1,29 @@
+source_id: 153
+
+common_name: Cassiopeia A
+gamma_names: []
+other_names: [Cas A, 3C461, G111.7-2.1]
+
+where: gal
+classes: [snr]
+
+discoverer: hegra
+seen_by: [hegra, magic, veritas]
+discovery_date: 2001-04
+
+tevcat_id: 82
+tevcat2_id: 3dz45u
+tevcat_name: TeV J2323+588
+
+tgevcat_id: 153
+tgevcat_name: TeV J2323+5848
+
+pos:
+  simbad_id: Cassiopeia A
+  ra: 350.85
+  dec: 58.815
+
+reference_ids:
+- 2010ApJ...714..163A
+- 2001A&A...370..112A
+- 2015arXiv151100309G

--- a/docs/data/sources/tev-000154.yaml
+++ b/docs/data/sources/tev-000154.yaml
@@ -1,0 +1,32 @@
+source_id: 154
+
+common_name: 1ES 2344+514
+gamma_names: []
+other_names: []
+
+where: egal
+classes: [hbl]
+
+discoverer: whipple
+seen_by: [whipple, hegra, magic, veritas]
+discovery_date: 1998-07
+
+tevcat_id: 77
+tevcat2_id: FcTRDg
+tevcat_name: TeV J2347+517
+
+tgevcat_id: 154
+tgevcat_name: TeV J2346+5142
+
+pos:
+  simbad_id: 1ES 2344+514
+  ra: 356.770153
+  dec: 51.704967
+
+reference_ids:
+- 1998ApJ...501..616C
+- 2005ApJ...634..947S
+- 2007ApJ...662..892A
+- 2011ApJ...738..169A
+- 2013A&A...556A..67A
+- 2017MNRAS.471.2117A

--- a/docs/data/sources/tev-000155.yaml
+++ b/docs/data/sources/tev-000155.yaml
@@ -1,0 +1,28 @@
+source_id: 155
+
+common_name: H 2356-309
+gamma_names: [HESS J2359-306]
+other_names: [1H 2354-315]
+
+where: egal
+classes: [hbl]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2006-04
+
+tevcat_id: 101
+tevcat2_id: VIbvxm
+tevcat_name: TeV J2359-306
+
+tgevcat_id: 155
+tgevcat_name: TeV J2359-3037
+
+pos:
+  simbad_id: H 2356-309
+  ra: 359.7829583
+  dec: -30.6279694
+
+reference_ids:
+- 2010A&A...516A..56H
+- 2006A&A...455..461A

--- a/docs/data/sources/tev-000156.yaml
+++ b/docs/data/sources/tev-000156.yaml
@@ -1,0 +1,32 @@
+source_id: 156
+
+common_name: HESS J1800-240B
+gamma_names:
+- HESS J1800-240B
+other_names: []
+
+where: gal
+classes: [snr, mc]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2008-04
+
+tevcat_id: 164
+tevcat2_id: mxBSx6
+tevcat_name: TeV J1800-240
+
+tgevcat_id: 111
+tgevcat_name: TeV J1800-2359
+
+reference_ids:
+- 2008A&A...481..401A
+- 2016JHEAp..11....1H
+
+pos:
+  simbad_id: HESS J1800-240B
+  ra: 270.1083
+  dec: -24.0383
+
+notes: |
+  tgevcat_name: TeV J1800-2359 represents both HESS J1800-240A and HESS J1800-240B.

--- a/docs/data/sources/tev-000157.yaml
+++ b/docs/data/sources/tev-000157.yaml
@@ -1,0 +1,27 @@
+source_id: 157
+
+common_name: HESS J1852-000
+gamma_names: [HESS J1852-000]
+other_names: [Kes 78]
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2011-08
+
+tevcat_id: 280
+tevcat2_id: xI7npJ
+tevcat_name: TeV J1852-000
+
+# Note: this source is not listed in tgevcat yet
+
+pos:
+  simbad_id: HESS J1852-000
+  ra: 283.0
+  dec: 0.0
+
+reference_ids:
+- 2011ICRC....7...76K
+- 2016ApJ...818...63B

--- a/docs/data/sources/tev-000158.yaml
+++ b/docs/data/sources/tev-000158.yaml
@@ -1,0 +1,31 @@
+source_id: 158
+
+common_name: SNR G323.7-01.0
+gamma_names: [HESS J1534-571]
+other_names: []
+
+where: gal
+classes: [snr]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2015-07
+
+tevcat_id: 268
+tevcat2_id: dwdrDT
+tevcat_name: TeV J1534-571
+
+# Note: this source is not listed in tgevcat yet
+
+# The SNR or HESS source is not listed in SIMBAD yet.
+# But the SNR is listed in SNRCat here:
+# http://www.physics.umanitoba.ca/snr/SNRcat/SNRrecord.php?id=G323.7m01.0
+# SkyCoord('15h34m30s -57d12m03s', frame='icrs')
+# TODO: this source is listed as `simbad_id`, but it's not SIMBAD!?
+pos:
+  simbad_id: SNR G323.7-01.0
+  ra: 233.62499
+  dec: -57.20083
+
+reference_ids:
+- 2015arXiv150903872P

--- a/docs/data/sources/tev-000159.yaml
+++ b/docs/data/sources/tev-000159.yaml
@@ -1,0 +1,32 @@
+source_id: 159
+
+common_name: Arc source
+gamma_names: [HESS J1746-285, VER J1746-289]
+other_names:
+- SNR G0.13-0.13
+- G0.13-0.11
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2015-07
+
+tevcat_id: 277
+tevcat2_id: LsZtAg
+tevcat_name: TeV J1746-289
+
+# Note: this source is not listed in tgevcat yet
+
+# TeV source position taken from 2015arXiv151004518L
+# SkyCoord(0.14, -0.114, unit='deg', frame='galactic').icrs
+# TODO: this should not be `simbad_id` ... move to `inputs/papers`
+pos:
+  simbad_id: Arc source
+  ra: 266.599
+  dec: -28.875
+
+reference_ids:
+- 2015arXiv151004518L
+- 2015arXiv150806311S

--- a/docs/data/sources/tev-000160.yaml
+++ b/docs/data/sources/tev-000160.yaml
@@ -1,0 +1,27 @@
+source_id: 160
+
+common_name: HESS J1813-126
+gamma_names: [HESS J1813-126]
+other_names: [PSR J1813-1246]
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2015-08
+
+tevcat_id: 270
+tevcat2_id: 6hCJvz
+tevcat_name: TeV J1813-126
+
+# Note: this source is not listed in tgevcat yet
+
+pos:
+  simbad_id: PSR J1813-1246
+  ra: 273.35
+  dec: -12.77
+
+reference_ids:
+- 2015arXiv151004518L
+- 2015arXiv150806311S

--- a/docs/data/sources/tev-000161.yaml
+++ b/docs/data/sources/tev-000161.yaml
@@ -1,0 +1,28 @@
+source_id: 161
+
+common_name: HESS J1826-130
+gamma_names: [HESS J1826-130]
+other_names: [PSR J1826-1256, PWN G018.5-00.4]
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2015-07
+
+tevcat_id: 271
+tevcat2_id: BpWYND
+tevcat_name: TeV J1826-130
+
+# Note: this source is not listed in tgevcat yet
+
+pos:
+  simbad_id: PSR J1826-1256
+  ra: 276.50417
+  dec: -13.09111
+
+reference_ids:
+- https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf
+- 2016MNRAS.458.2813V
+- 2017arXiv170107002A

--- a/docs/data/sources/tev-000162.yaml
+++ b/docs/data/sources/tev-000162.yaml
@@ -1,0 +1,28 @@
+source_id: 162
+
+common_name: HESS J1828-099
+gamma_names: [HESS J1828-099]
+other_names: []
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2015-07
+
+tevcat_id: 272
+tevcat2_id: 2Jribp
+tevcat_name: TeV J1828-099
+
+# Note: this source is not listed in tgevcat yet
+
+# TeV source position taken from HESS_HGPS_ICRC2015_Deil.pdf (slide 24)
+# TODO: this should not be `simbad_id` ... move to `inputs/papers`
+pos:
+  simbad_id: HESS J1828-099
+  ra: 277.25
+  dec: -9.99
+
+reference_ids:
+- https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf

--- a/docs/data/sources/tev-000163.yaml
+++ b/docs/data/sources/tev-000163.yaml
@@ -1,0 +1,28 @@
+source_id: 163
+
+common_name: HESS J1832-085
+gamma_names: [HESS J1832-085]
+other_names: [PSR J1832-0836]
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2015-07
+
+tevcat_id: 273
+tevcat2_id: trW4uy
+tevcat_name: TeV J1832-085
+
+# Note: this source is not listed in tgevcat yet
+
+# TeV source position taken from HESS_HGPS_ICRC2015_Deil.pdf (slide 25)
+# TODO: this should not be `simbad_id` ... move to `inputs/papers`
+pos:
+  simbad_id: HESS J1832-085
+  ra: 278.13
+  dec: -8.51
+
+reference_ids:
+- https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf

--- a/docs/data/sources/tev-000164.yaml
+++ b/docs/data/sources/tev-000164.yaml
@@ -1,0 +1,32 @@
+source_id: 164
+
+common_name: HESS J1844-030
+gamma_names: [HESS J1844-030]
+other_names:
+- PSR J1832-0836
+- AX J1844.6-0305
+- PMN J1844-0306
+- SNR G29.4+0.1
+
+where: gal
+classes: [unid]
+
+discoverer: hess
+seen_by: [hess]
+discovery_date: 2015-07
+
+tevcat_id: 274
+tevcat2_id: OEZygN
+tevcat_name: TeV J1844-030
+
+# Note: this source is not listed in tgevcat yet
+
+# TeV source position taken from HESS_HGPS_ICRC2015_Deil.pdf (slide 25)
+# TODO: this should not be `simbad_id` ... move to `inputs/papers`
+pos:
+  simbad_id: HESS J1844-030
+  ra: 281.17
+  dec: -3.10
+
+reference_ids:
+- https://indico.cern.ch/event/344485/contributions/1744018/attachments/1136486/1626371/HESS_HGPS_ICRC2015_Deil.pdf

--- a/docs/data/sources/tev-000165.yaml
+++ b/docs/data/sources/tev-000165.yaml
@@ -1,0 +1,28 @@
+source_id: 165
+
+common_name: VER J1746-289
+gamma_names: [VER J1746-289, HESS J1746-285, MAGIC J1746.4-2853]
+other_names: [Arc source, GC Radio Arc]
+
+where: gal
+classes: [unid]
+
+discoverer: veritas
+seen_by: [veritas, hess, magic]
+discovery_date: 2014-06
+
+tevcat_id: 269
+tevcat2_id: LsZtAg
+tevcat_name: TeV J1746-289
+
+# Note: this source is not listed in tgevcat yet
+
+pos:
+  simbad_id: VER J1746-289
+  ra: 266.5821
+  dec: -28.966226
+
+reference_ids:
+- 2016ApJ...821..129A
+- 2017A&A...601A..33A
+- 2015ICRC...34..838L

--- a/docs/data/sources/tev-000166.yaml
+++ b/docs/data/sources/tev-000166.yaml
@@ -1,0 +1,28 @@
+source_id: 166
+
+common_name: Crab pulsar
+gamma_names: []
+other_names: [PSR 0531+21, V* CM Tau]
+
+where: gal
+classes: [psr]
+
+discoverer: magic
+seen_by: [magic, veritas]
+discovery_date: 2008-11
+
+tevcat_id: 129
+tevcat2_id: 06r8mb
+tevcat_name: TeV J0534+220p
+
+# Note: this source is not listed in tgevcat yet
+
+pos:
+  simbad_id: V* CM Tau
+  ra: 83.63307625
+  dec: 22.014493278
+
+reference_ids:
+- 2008Sci...322.1221A
+- 2011Sci...334...69V
+- 2011ApJ...742...43A

--- a/docs/data/sources/tev-000167.yaml
+++ b/docs/data/sources/tev-000167.yaml
@@ -1,0 +1,26 @@
+source_id: 167
+
+common_name: PKS 1441+25
+gamma_names: [VER J1443+250]
+fermi_names: [3FGL J1443.9+2502]
+other_names: []
+
+where: egal
+classes: [fsrq]
+
+discoverer: magic
+seen_by: [magic, veritas]
+discovery_date: 2015-03
+
+tevcat_id: 263
+tevcat2_id: IqGXlk
+tevcat_name: TeV J1443+250
+
+pos:
+  simbad_id: 7C 1441+2514
+  ra: 220.987051
+  dec: 25.029025
+
+reference_ids:
+- 2015ApJ...815L..23A
+- 2015ApJ...815L..22A

--- a/gammacat/collection.py
+++ b/gammacat/collection.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 from pathlib import Path
 from astropy.utils import lazyproperty
 from gammapy.catalog.gammacat import GammaCatResourceIndex, GammaCatResource
+from .src_info import SrcInfo
 from .sed import SED
 from .lightcurve import LightCurve
 from .dataset import DataSet
@@ -193,6 +194,8 @@ class CollectionMaker:
         step = self.config.step
         if step == 'all':
             self.process_all()
+        elif step == 'source-info':
+            self.process_src_info()
         elif step == 'input-index':
             self.make_index_file_for_input()
         elif step == 'sed':
@@ -242,6 +245,13 @@ class CollectionMaker:
             path.parent.mkdir(parents=True, exist_ok=True)
             log.info('Writing {}'.format(path))
             lightcurve.table.write(str(path), format='ascii.ecsv')
+
+    def process_src_info(self):
+        for filename in self.input_data.src_info_list:
+            log.debug(' Processing basic source info file: {}'.format(filename))
+            src_info = SrcInfo.read(filename)
+            path = self.config.path / 'sources' / filename.parts[-1]
+            src_info.write(path)
 
     def process_datasets(self):
         for info_filename in self.input_data.info_yaml_list:

--- a/gammacat/collection.py
+++ b/gammacat/collection.py
@@ -47,6 +47,12 @@ class CollectionConfig:
         self.index_sources_json = self.out_path / 'gammacat-sources.json'
         self.index_input_json = self.in_path / 'input-datasets.json'
 
+    def bsi_files(self, relative_to_repo=False):
+        filenames = self.list_of_files('sources/*.yaml')
+        if relative_to_repo:
+            filenames = [str(self.out_path / filename) for filename in filenames]
+        return filenames
+
     def sed_files(self, relative_to_repo=False):
         filenames = self.list_of_files('data/*/*sed*.ecsv')
         if relative_to_repo:
@@ -309,6 +315,10 @@ class CollectionMaker:
             resources.append(resource)
         for filename in self.config.ds_files():
             resource = DataSet.read(self.config.out_path / filename).resource
+            resource.location = filename
+            resources.append(resource)
+        for filename in self.config.bsi_files():
+            resource = SrcInfo.read(self.config.out_path / filename).resource
             resource.location = filename
             resources.append(resource)
 

--- a/gammacat/input.py
+++ b/gammacat/input.py
@@ -307,6 +307,12 @@ class InputData:
     """
 
     @property
+    def src_info_list(self):
+        """List of all basic source info files in input/sources"""
+        path = gammacat_info.base_dir / 'input/sources'
+        return sorted(path.glob('tev*.yaml'))
+
+    @property
     def lightcurve_file_list(self):
         """List of all lightcurve files in the input folder."""
         path = gammacat_info.base_dir / 'input/data'

--- a/gammacat/src_info.py
+++ b/gammacat/src_info.py
@@ -9,6 +9,7 @@ __all__ = [
 
 log = logging.getLogger(__name__)
 
+
 class SrcInfo:
     """Process a basic source info file"""
     resource_type = 'bsi'
@@ -25,11 +26,13 @@ class SrcInfo:
 
     @classmethod
     def _read_resource_info(cls, data, location):
-        file_id = -1
         return GammaCatResource(
             source_id=data['source_id'],
-            reference_id=data['reference_ids'],
-            file_id=file_id,
+            # There isn't a unique reference_id for a given source
+            # So we could fill nothing here or a comma-separated list of reference_id
+            # For now, we will nothing, probably that is OK as long-term solution.
+            reference_id='',
+            file_id=-1,
             type=cls.resource_type,
             location=location
         )

--- a/gammacat/src_info.py
+++ b/gammacat/src_info.py
@@ -13,13 +13,26 @@ class SrcInfo:
     """Process a basic source info file"""
     resource_type = 'bsi'
 
-    def __init__(self, data):
+    def __init__(self, data, resource):
         self.data = data
+        self.resource = resource
 
     @classmethod
     def read(cls, filename):
         data = load_yaml(filename)
-        return cls(data)
+        resource = cls._read_resource_info(data, filename)
+        return cls(data=data, resource=resource)
+
+    @classmethod
+    def _read_resource_info(cls, data, location):
+        file_id = -1
+        return GammaCatResource(
+            source_id=data['source_id'],
+            reference_id=data['reference_ids'],
+            file_id=file_id,
+            type=cls.resource_type,
+            location=location
+        )
 
     def write(self, filename):
         write_yaml(self.data, filename)

--- a/gammacat/src_info.py
+++ b/gammacat/src_info.py
@@ -1,0 +1,25 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import logging
+from .utils import load_yaml, write_yaml
+from gammapy.catalog.gammacat import GammaCatResource
+
+__all__ = [
+    'SrcInfo',
+]
+
+log = logging.getLogger(__name__)
+
+class SrcInfo:
+    """Process a basic source info file"""
+    resource_type = 'bsi'
+
+    def __init__(self, data):
+        self.data = data
+
+    @classmethod
+    def read(cls, filename):
+        data = load_yaml(filename)
+        return cls(data)
+
+    def write(self, filename):
+        write_yaml(self.data, filename)

--- a/make.py
+++ b/make.py
@@ -57,7 +57,7 @@ def cli(ctx, log_level, show_warnings):
 
 @cli.command(name='collection')
 @click.option('--step', default='all',
-              type=click.Choice(['all', 'sed', 'lightcurve', 'dataset', 'input-index', 'output-index']))
+              type=click.Choice(['all', 'source-info', 'sed', 'lightcurve', 'dataset', 'input-index', 'output-index']))
 @click.pass_obj
 def cli_collection(global_config, step):
     """Make gamma-cat data collection."""


### PR DESCRIPTION
 This PR adds all basic source info files which are stored in $GAMMACAT/input/sources to the output collection, more precisely, to $GAMMACAT/docs/data/sources.
See comment of @cdeil here:
https://github.com/gammapy/gamma-cat/issues/177#issuecomment-347310709

Ready to merge (but look at the inline comment!)