### PR TITLE
Publication list

### DIFF
--- a/gammacat/webpage.py
+++ b/gammacat/webpage.py
@@ -9,6 +9,7 @@ from gammapy.catalog import GammaCatResourceIndex
 from .input import BasicSourceList
 from .info import gammacat_info
 from .utils import load_json, jinja_env
+from pathlib import Path
 
 __all__ = [
     'WebpageConfig',
@@ -44,7 +45,25 @@ class WebpageMaker:
         log.info('Make webpage ...')
         self.make_source_list_page()
         self.make_source_detail_pages()
+        self.make_publication_list()
         self.copy_data()
+
+    def make_publication_list(self):
+        publications = self.resources.unique_reference_ids
+        # The first entry of publications is empty, hence, delete first entry
+        del publications[0]
+
+        ctx = {
+            'publications' : sorted(publications)
+            }
+
+        template = jinja_env.get_template('publication_list.txt')
+        txt = template.render(ctx)
+
+        path = gammacat_info.webpage_path / 'use/publication_list.rst'
+
+        log.info(f'Writing {path}')
+        path.write_text(txt)
 
     def copy_data(self):
         """Copy output data folder to docs HTML output folder,

--- a/make.py
+++ b/make.py
@@ -92,6 +92,7 @@ def cli_clean():
         'webpage/_build',
         'webpage/use/sources',
         'webpage/use/source_list.rst',
+        'webpage/use/publication_list.rst',
     ])
     log.info(f'Executing command: {cmd}')
     subprocess.call(cmd, shell=True)

--- a/webpage/index.rst
+++ b/webpage/index.rst
@@ -31,6 +31,8 @@ This site is organised in the following sections:
    :caption: User Documentation
 
    use/index
+   use/source_list
+   use/publication_list
    stats/index
    changes
 

--- a/webpage/templates/publication_list.txt
+++ b/webpage/templates/publication_list.txt
@@ -1,0 +1,10 @@
+.. include:: ../references.rst
+
+Data collection by publication
+==============================
+
+The following publications are being part of gamma-cat:
+
+{% for publication in publications %}
+* {{ publication }}
+{% endfor %}

--- a/webpage/use/index.rst
+++ b/webpage/use/index.rst
@@ -29,5 +29,3 @@ Why multiple formats?
 * The ECSV and YAML variant are more for us working on gamma-cat,
   to have a text-based, version control friendly format where it's
   easy to see which changes occurred from one version to the next.
-
-.. include:: source_list.rst


### PR DESCRIPTION
Add a section of all publications of which there is being data in gamma-cat.

The main commit of this PR is the second one "Add publication list to webpage". The other one is a copy of PR 201, hence, this PR here needs a rebase after merging PR 201.

My idea is that later on we will have a list of publications as links and for each publication all sees, datasets and lightcurves. Similar to the source list.