### PR TITLE
RX J1713 position

### DIFF
--- a/input/sources/tev-000096.yaml
+++ b/input/sources/tev-000096.yaml
@@ -21,10 +21,14 @@ tevcat_name: TeV J1713-397
 tgevcat_id: 96
 tgevcat_name: TeV J1713-3945
 
+# The position for this TeV source in SIMBAD is no good.
+# See https://github.com/gammapy/gamma-cat/issues/96
+# We chose to put the best-fit position from 2016arXiv160908671H here instead,
+# to avoid this source appearing at an offset of ~ 0.2 deg from the actual position.
 pos:
   simbad_id: RX J1713.7-3946
-  ra: 258.1125
-  dec: -39.6867
+  ra: 258.3550109863281
+  dec: -39.770999908447266
 
 reference_ids:
 - 2004Natur.432...75A

--- a/output/sources/tev-000096.yaml
+++ b/output/sources/tev-000096.yaml
@@ -21,10 +21,14 @@ tevcat_name: TeV J1713-397
 tgevcat_id: 96
 tgevcat_name: TeV J1713-3945
 
+# The position for this TeV source in SIMBAD is no good.
+# See https://github.com/gammapy/gamma-cat/issues/96
+# We chose to put the best-fit position from 2016arXiv160908671H here instead,
+# to avoid this source appearing at an offset of ~ 0.2 deg from the actual position.
 pos:
   simbad_id: RX J1713.7-3946
-  ra: 258.1125
-  dec: -39.6867
+  ra: 258.3550109863281
+  dec: -39.770999908447266
 
 reference_ids:
 - 2004Natur.432...75A


### PR DESCRIPTION
Currently we have this position for RX J1713 taken from SIMBAD:
https://github.com/gammapy/gamma-cat/blame/master/input/sources/tev-000096.yaml#L24
```
pos:
    simbad_id: RX J1713.7-3946
    ra: 258.1125
    dec: -39.6867
```

While preparing the CTA 1DC sky model, I noticed that this position doesn't agree with the TeV shell center.

None of these positions from SIMBAD match the TeV shell center (all offset ~ 0.2 deg).
Not even the one for 'HESS J1713-397'!
```
>>> SkyCoord.from_name('HESS J1713-397')
<SkyCoord (ICRS): (ra, dec) in deg
    ( 258.1125, -39.6867)>
>>> SkyCoord.from_name('SNR G347.3-00.5')
<SkyCoord (ICRS): (ra, dec) in deg
    ( 258.1125, -39.6867)>
>>> SkyCoord.from_name('RX J1713.7-3946')
<SkyCoord (ICRS): (ra, dec) in deg
    ( 257.991, -39.862)>
```

TeVCat has this position (see http://tevcat.uchicago.edu/?mode=1&showsrc=84), saying that it's taken from the HESS 2006 and 2007 paper:
```
R.A.: | 17 13 33.6 (hh mm ss)
Dec.: | -39 45 36 (dd mm ss)
Gal Long: | 347.34 (deg)
Gal Lat: | -0.47 (deg)
```

This is a reminder issue to fix / clear this up in gamma-cat.
I haven't looked at the output catalog, but in the basic source info file, we shouldn't keep the incorrect position, so at least that needs a change.