### PR TITLE
Add data for 2018arXiv180106020H

### DIFF
--- a/input/data/2018/2018arXiv180106020H/info.yaml
+++ b/input/data/2018/2018arXiv180106020H/info.yaml
@@ -1,0 +1,15 @@
+reference_id: 2018arXiv180106020H
+source_id: [83, 134, 158]
+telescope: [hess]
+
+datasets:
+- tev-000083.yaml
+- tev-000083-sed.ecsv
+- tev-000134.yaml
+- tev-000134-sed.ecsv
+- tev-000158.yaml
+- tev-000158-sed.ecsv
+
+data_entry:
+  status: complete 
+  reviewed: no

--- a/input/data/2018/2018arXiv180106020H/tev-000083-sed.ecsv
+++ b/input/data/2018/2018arXiv180106020H/tev-000083-sed.ecsv
@@ -1,0 +1,33 @@
+# %ECSV 0.9
+# ---
+# datatype:
+# - {name: e_ref, datatype: float32, unit: TeV}
+# - {name: dnde, datatype: float32, unit: cm-2 s-1 TeV-1}
+# - {name: dnde_errp, datatype: float32, unit: cm-2 s-1 TeV-1}
+# - {name: dnde_errn, datatype: float32, unit: cm-2 s-1 TeV-1}
+# meta: !!omap
+# - data_type: sed
+# - source_id: 83
+# - reference_id: 2018arXiv180106020H
+# - telescope: hess
+# - comments: |
+#     Spectral points obtained via email by Daniel Gottschall on Nov 3, 2016
+#     TODO POSSIBLY NOT FINAL!
+e_ref dnde dnde_errp dnde_errn
+ 0.35 1.13e-010 4.32e-011 4.18e-011
+ 0.43 7.80e-011 1.55e-011 1.52e-011
+ 0.51 2.57e-011 7.33e-012 7.18e-012
+ 0.62 2.76e-011 4.66e-012 4.56e-012
+ 0.75 1.24e-011 2.92e-012 2.84e-012
+ 0.91 1.13e-011 2.01e-012 1.95e-012
+ 1.10 6.39e-012 1.34e-012 1.29e-012
+ 1.33 5.36e-012 9.30e-013 8.95e-013
+ 1.61 2.73e-012 6.30e-013 6.04e-013
+ 1.96 1.72e-012 4.37e-013 4.17e-013
+ 2.37 1.26e-012 3.01e-013 2.85e-013
+ 2.87 1.05e-012 2.23e-013 2.10e-013
+ 3.47 4.15e-013 1.42e-013 1.32e-013
+ 4.21 2.88e-013 1.01e-013 9.30e-014
+ 5.10 2.42e-013 7.36e-014 6.63e-014
+ 6.18 1.66e-013 5.39e-014 4.77e-014
+13.77 7.01e-015 3.22e-015 2.98e-015

--- a/input/data/2018/2018arXiv180106020H/tev-000083.yaml
+++ b/input/data/2018/2018arXiv180106020H/tev-000083.yaml
@@ -1,0 +1,27 @@
+source_id: 83
+reference_id: 2018arXiv180106020H
+telescope: hess
+
+data:
+  livetime: 34.2h
+  significance: 25.2
+
+pos:
+  glon: {val: 331.47d, err: 0.01d}
+  glat: {val: -0.6d, err: 0.01d}
+
+morph:
+  type: shell
+  sigma: {val: 0.18d, err: 0.01d}
+  sigma2: {val: 0.42d, err: 0.01d}
+
+spec:
+  model:
+    type: pl
+    parameters:
+      norm: {val: 5.86, err: 0.34, err_sys: 1.76, scale: 1e-12, unit: cm-2 s-1 TeV-1}
+      index: {val: 2.42, err: 0.06, err_sys: 0.2}
+      e_ref: {val: 1.15, unit: TeV}
+
+  theta: 0.49d
+  erange: {min: 0.32, max: 38.3, unit: TeV}

--- a/input/data/2018/2018arXiv180106020H/tev-000134-sed.ecsv
+++ b/input/data/2018/2018arXiv180106020H/tev-000134-sed.ecsv
@@ -1,0 +1,24 @@
+# %ECSV 0.9
+# ---
+# datatype:
+# - {name: e_ref, datatype: float32, unit: TeV}
+# - {name: dnde, datatype: float32, unit: cm-2 s-1 TeV-1}
+# - {name: dnde_errp, datatype: float32, unit: cm-2 s-1 TeV-1}
+# - {name: dnde_errn, datatype: float32, unit: cm-2 s-1 TeV-1}
+# meta: !!omap
+# - data_type: sed
+# - source_id: 134
+# - reference_id: 2018arXiv180106020H
+# - telescope: hess
+# - comments: |
+#     Spectral points obtained via email by Daniel Gottschall on Nov 3, 2016
+#     TODO POSSIBLY NOT FINAL!
+e_ref dnde dnde_errp dnde_errn
+ 0.88 3.52e-012 1.39e-012 1.37e-012
+ 1.22 2.03e-012 4.21e-013 4.17e-013
+ 1.77 9.90e-013 1.82e-013 1.80e-013
+ 2.60 4.30e-013 7.99e-014 7.87e-014
+ 3.80 1.83e-013 3.79e-014 3.72e-014
+ 5.56 5.26e-014 1.67e-014 1.63e-014
+ 8.17 2.28e-014 7.97e-015 7.69e-015
+19.64 8.80e-016 6.02e-016 5.81e-016

--- a/input/data/2018/2018arXiv180106020H/tev-000134.yaml
+++ b/input/data/2018/2018arXiv180106020H/tev-000134.yaml
@@ -1,0 +1,27 @@
+source_id: 134
+reference_id: 2018arXiv180106020H
+telescope: hess
+
+data:
+  livetime: 121.1h
+  significance: 17.3
+
+pos:
+  glon: {val: 44.46d, err: 0.02d}
+  glat: {val: -0.13d, err: 0.02d}
+
+morph:
+  type: shell
+  sigma: {val: 0.32d, err: 0.02d}
+  sigma2: {val: 0.49d, err: 0.04d}
+
+spec:
+  model:
+    type: pl
+    parameters:
+      norm: {val: 4.82, err: 0.43, err_sys: 1.45, scale: 1e-12, unit: cm-2 s-1 TeV-1}
+      index: {val: 2.56, err: 0.09, err_sys: 0.2}
+      e_ref: {val: 2.25, unit: TeV}
+
+  theta: 0.56d
+  erange: {min: 0.68, max: 61.9, unit: TeV}

--- a/input/data/2018/2018arXiv180106020H/tev-000158-sed.ecsv
+++ b/input/data/2018/2018arXiv180106020H/tev-000158-sed.ecsv
@@ -1,0 +1,24 @@
+# %ECSV 0.9
+# ---
+# datatype:
+# - {name: e_ref, datatype: float32, unit: TeV}
+# - {name: dnde, datatype: float32, unit: cm-2 s-1 TeV-1}
+# - {name: dnde_errp, datatype: float32, unit: cm-2 s-1 TeV-1}
+# - {name: dnde_errn, datatype: float32, unit: cm-2 s-1 TeV-1}
+# meta: !!omap
+# - data_type: sed
+# - source_id: 158
+# - reference_id: 2018arXiv180106020H
+# - telescope: hess
+# - comments: |
+#     Spectral points obtained via email by Daniel Gottschall on Nov 3, 2016
+#     TODO POSSIBLY NOT FINAL!
+e_ref dnde dnde_errp dnde_errn
+ 0.54 8.29e-012 3.58e-012 3.54e-012
+ 0.75 7.63e-012 1.24e-012 1.22e-012
+ 1.09 2.06e-012 5.26e-013 5.19e-013
+ 1.61 9.94e-013 2.42e-013 2.38e-013
+ 2.36 4.36e-013 1.10e-013 1.07e-013
+ 3.45 1.76e-013 5.11e-014 4.96e-014
+ 5.05 5.69e-014 2.34e-014 2.25e-014
+14.00 2.51e-015 1.34e-015 1.29e-015

--- a/input/data/2018/2018arXiv180106020H/tev-000158.yaml
+++ b/input/data/2018/2018arXiv180106020H/tev-000158.yaml
@@ -1,0 +1,27 @@
+source_id: 158
+reference_id: 2018arXiv180106020H
+telescope: hess
+
+data:
+  livetime: 61.8h
+  significance: 9.3
+
+pos:
+  glon: {val: 323.70d, err: 0.02d}
+  glat: {val: -1.02d, err: 0.03d}
+
+morph:
+  type: shell
+  sigma: {val: 0.28d, err: 0.06d}
+  sigma2: {val: 0.40d, err: 0.04d}
+
+spec:
+  model:
+    type: pl
+    parameters:  
+      norm: {val: 1.29, err: 0.12, err_sys: 0.39, scale: 1e-12, unit: cm-2 s-1 TeV-1}
+      index: {val: 2.51, err: 0.09, err_sys: 0.2}
+      e_ref: {val: 1.40, unit: TeV}
+
+  theta: 0.47d
+  erange: {min: 0.42, max: 61.9, unit: TeV}

--- a/input/gammacat/gamma_cat_dataset.yaml
+++ b/input/gammacat/gamma_cat_dataset.yaml
@@ -248,7 +248,7 @@
   reference_id: 2015ApJ...802...65A, 2015ApJ...799....7A, 2012ApJ...748...46A,2008A&A...477..481A
 - source_id: 83
   status: source
-  reference_id: 2006ApJ...636..777A
+  reference_id: 2006ApJ...636..777A, 2018arXiv180106020H
 - source_id: 84
   status: source
   reference_id: 2006ApJ...636..777A
@@ -401,7 +401,7 @@
   reference_id: 2016arXiv160900600H
 - source_id: 134
   status: source
-  reference_id: 2008A&A...484..435A
+  reference_id: 2008A&A...484..435A, 2018arXiv180106020H
 - source_id: 135
   status: source
   reference_id: 2012A&A...541A..13A
@@ -473,7 +473,7 @@
   reference_id:
 - source_id: 158
   status: source
-  reference_id:
+  reference_id: 2018arXiv180106020H
 - source_id: 159
   status: source
   reference_id:


### PR DESCRIPTION
This PR adds data for the new shells paper: https://arxiv.org/abs/1801.06020

I'll merge this in now, and then ask the authors to review, and to provide an aux page that we can reference for the spectral point info.