### PR TITLE
Restructure of folders in output/data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ ENV/
 
 .idea
 
+.pytest_cache
+.cache
+
 webpage/_build
 webpage/data
 webpage/use/source_list.rst

--- a/gammacat/collection.py
+++ b/gammacat/collection.py
@@ -81,16 +81,25 @@ class CollectionConfig:
         else:
             path = self.out_path
 
-        path = path / 'data' / meta['reference_folder']
+        path = path / 'data' / meta['year']
 
-        tag = GammaCatStr.dataset_filename(meta)
+        tag = GammaCatStr.data_filename(meta)
 
         if meta['datatype'] == 'sed':
-            path = path / '{}_sed.ecsv'.format(tag)
+            if meta['file_id'] != 1:
+                path = path / '{}-sed-{}.ecsv'.format(tag, meta['file_id'])
+            else:
+                path = path / '{}-sed.ecsv'.format(tag)
         elif meta['datatype'] == 'lc':
-            path = path / '{}_lc.ecsv'.format(tag)
+            if meta['file_id'] != -1:
+                path = path / '{}-lc-{}.ecsv'.format(tag, meta['file_id'])
+            else:
+                path = path / '{}-lc.ecsv'.format(tag)
         elif meta['datatype'] == 'ds':
-            path = path / '{}_ds.yaml'.format(tag)
+            if meta['file_id'] != -1:
+                path = path / '{}-{}.yaml'.format(tag, meta['file_id'])
+            else:
+                path = path / '{}.yaml'.format(tag)
         else:
             raise ValueError('Invalid datatype: {}'.format(meta['datatype']))
 
@@ -103,20 +112,23 @@ class CollectionConfig:
         # import IPython; IPython.embed(); 1/0
         meta = sed.table.meta.copy()
         meta['datatype'] = 'sed'
-        meta['reference_folder'] = Path(sed.resource.location).parts[-2]
+        meta['year'] = sed.resource.reference_id[:4]
+        meta['file_id'] = sed.resource.file_id
         return self.make_filename(meta, relative_to_index=relative_to_index)
 
     def make_lc_path(self, lc, *, relative_to_index):
         meta = lc.table.meta.copy()
         meta['datatype'] = 'lc'
-        meta['reference_folder'] = Path(lc.resource.location).parts[-2]
+        meta['year'] = lc.resource.reference_id[:4]
+        meta['file_id'] = lc.resource.file_id
         return self.make_filename(meta, relative_to_index=relative_to_index)
 
     def make_dataset_path(self, dataset, *, relative_to_index):
         meta = OrderedDict()
         meta['datatype'] = 'ds'
-        meta['reference_folder'] = Path(dataset.resource.location).parts[-2]
         meta['reference_id'] = dataset.resource.reference_id
+        meta['file_id'] = dataset.resource.file_id
+        meta['year'] = dataset.resource.reference_id[:4]
         meta['source_id'] = dataset.resource.source_id
         return self.make_filename(meta, relative_to_index=relative_to_index)
 

--- a/gammacat/info.py
+++ b/gammacat/info.py
@@ -58,15 +58,13 @@ class GammaCatStr:
     """
 
     @staticmethod
-    def dataset_filename(meta):
-        return 'gammacat_' + GammaCatStr.dataset_str(meta)
+    def reference_folder(meta):
+        return GammaCatStr.reference_id_str(meta)
 
     @staticmethod
-    def dataset_str(meta):
-        ss = GammaCatStr.reference_id_str(meta['reference_id'])
-        ss += '_'
-        ss += GammaCatStr.source_id_str(meta['source_id'])
-        return ss
+    def data_filename(meta):
+        return GammaCatStr.reference_folder(meta['reference_id']) + \
+            '/tev-' + GammaCatStr.source_id_str(meta['source_id'])
 
     @staticmethod
     def source_id_str(source_id):

--- a/gammacat/tests/test_info.py
+++ b/gammacat/tests/test_info.py
@@ -6,4 +6,4 @@ def test_gammacat_str():
     assert GammaCatStr.source_id_str(42) == '000042'
 
     meta = dict(source_id=42, reference_id='2015A&A...577A.131H')
-    assert GammaCatStr.dataset_filename(meta) == 'gammacat_2015A%26A...577A.131H_000042'
+    assert GammaCatStr.data_filename(meta) == '2015A%26A...577A.131H/tev-000042'


### PR DESCRIPTION
This PR handles the ideas from #198.

The new structure in the output folder is similar to the one in the input folder. The only difference is the "missing" info.yaml files which are not necessary in the output folder.

@cdeil If you agree with the first commit, I will do a "update output" commit and fix the errors of travis CI which will occur afterwards