### PR TITLE
Added two published MAGIC papers on blazar 1510 yaml file

### DIFF
--- a/input/sources/tev-000078.yaml
+++ b/input/sources/tev-000078.yaml
@@ -10,7 +10,7 @@ where: egal
 classes: [fsrq]
 
 discoverer: hess
-seen_by: [hess]
+seen_by: [hess,magic]
 discovery_date: 2010-03
 
 tevcat_id: 206
@@ -27,3 +27,5 @@ pos:
 
 reference_ids:
 - 2013A&A...554A.107H
+- 2014A&A...569A..46A
+- 2017A&A...603A..29A


### PR DESCRIPTION
I added the two references for the MAGIC observations of 1510 in 2014 and 2017. I will add the data later on.