### PR TITLE
Update reference detail on RTD

### DIFF
--- a/gammacat/info.py
+++ b/gammacat/info.py
@@ -30,6 +30,10 @@ class GammaCatInfo:
         self.out_path = self.base_dir / 'output'
         self.webpage_path = self.base_dir / 'webpage'
 
+        # Input and output URL on github
+        self.input_url = 'https://github.com/gammapy/gamma-cat/blob/master/input'
+        self.output_url = 'https://github.com/gammapy/gamma-cat/blob/master/output'
+
         self.description = "An open data collection and source catalog for gamma-ray astronomy"
 
         self.datetime = str(Time.now())

--- a/gammacat/webpage.py
+++ b/gammacat/webpage.py
@@ -62,10 +62,21 @@ class WebpageMaker:
         references_data = []
         for reference_id in reference_ids:
             ads_url = f'https://ui.adsabs.harvard.edu/#abs/{reference_id}'
+            year = {reference_id[:4]}
+            in_folder = f'{gammacat_info.input_url}/data/{year}/{urllib.parse.quote(reference_id)}'
+            out_folder = f'{gammacat_info.output_url}/data/{year}/{urllib.parse.quote(reference_id)}'
+            data_status = (load_yaml(gammacat_info.base_dir / 'input/data' \
+            / f'{reference_id[:4]}/{urllib.parse.quote(reference_id)}' / 'info.yaml')) \
+            ['data_entry']['status']
+            review_status = (load_yaml(gammacat_info.base_dir / 'input/data' \
+            / f'{reference_id[:4]}/{urllib.parse.quote(reference_id)}' / 'info.yaml')) \
+            ['data_entry']['reviewed']
             references_data.append(dict(
                 reference_title_underline='-' * len(reference_id),
                 reference_id=reference_id,
                 ads_url=ads_url,
+                input_folder=in_folder,
+                output_folder=out_folder,
             ))
         return references_data
 
@@ -136,7 +147,6 @@ class WebpageMaker:
 
     def make_reference_detail_page(self, reference):
         ctx = {'reference': reference}
-
         template = jinja_env.get_template('reference_detail.txt')
         txt = template.render(ctx)
 

--- a/gammacat/webpage.py
+++ b/gammacat/webpage.py
@@ -8,7 +8,7 @@ import urllib.parse
 from gammapy.catalog import GammaCatResourceIndex
 from .input import BasicSourceList
 from .info import gammacat_info
-from .utils import load_json, jinja_env
+from .utils import load_json, jinja_env, load_yaml
 from pathlib import Path
 
 __all__ = [
@@ -77,6 +77,8 @@ class WebpageMaker:
                 ads_url=ads_url,
                 input_folder=in_folder,
                 output_folder=out_folder,
+                data_entry_status=data_status,
+                data_review_status=review_status,
             ))
 
         return references_data

--- a/gammacat/webpage.py
+++ b/gammacat/webpage.py
@@ -78,6 +78,7 @@ class WebpageMaker:
                 input_folder=in_folder,
                 output_folder=out_folder,
             ))
+
         return references_data
 
     def run(self):
@@ -146,7 +147,10 @@ class WebpageMaker:
         path.write_text(txt)
 
     def make_reference_detail_page(self, reference):
-        ctx = {'reference': reference}
+        resources = []
+        for resource in (self.resource_index_output.query('reference_id == {!r}'.format(reference['reference_id']))).resources:
+            resources.append(dict(self.make_resource_info_for_template(resource)))
+        ctx = {'reference': reference, 'resources': resources}
         template = jinja_env.get_template('reference_detail.txt')
         txt = template.render(ctx)
 

--- a/webpage/templates/reference_detail.txt
+++ b/webpage/templates/reference_detail.txt
@@ -7,8 +7,8 @@ Basic info
 ----------
 
 * Reference: {{ reference.reference_id }}
-* TODO: link to input folder
-* TODO: link to output folder
+* Edit on github: `input/data/{{ reference.reference_id[:4] }}/{{ reference.reference_id }} <{{ reference.input_folder }}>`__
+* Catalog data on github: `output/data/{{ reference.reference_id[:4] }}/{{ reference.reference_id }} <{{ reference.output_folder }}>`__
 * ADS: `{{ reference.ads_url }} <{{ reference.ads_url}}>`__
 * TODO: summarise available data and data entry status
 

--- a/webpage/templates/reference_detail.txt
+++ b/webpage/templates/reference_detail.txt
@@ -15,4 +15,11 @@ Basic info
 Resources
 ---------
 
-* TODO
+{% for resource in resources %}
+* reference_id: **{{ resource.reference_id }}** , type: **{{ resource.type }}** , file_id: **{{ resource.file_id }}**
+    * `input/{{ resource.url_input }} <https://github.com/gammapy/gamma-cat/tree/master/input/{{ resource.url_input }}>`__
+    * `output/{{ resource.url_output }} <https://github.com/gammapy/gamma-cat/tree/master/output/{{ resource.url_output }}>`__
+    * `Download file <{{ resource.url_webpage }}>`__
+{% else %}
+* None
+{% endfor %}

--- a/webpage/templates/reference_detail.txt
+++ b/webpage/templates/reference_detail.txt
@@ -10,7 +10,10 @@ Basic info
 * Edit on github: `input/data/{{ reference.reference_id[:4] }}/{{ reference.reference_id }} <{{ reference.input_folder }}>`__
 * Catalog data on github: `output/data/{{ reference.reference_id[:4] }}/{{ reference.reference_id }} <{{ reference.output_folder }}>`__
 * ADS: `{{ reference.ads_url }} <{{ reference.ads_url}}>`__
-* TODO: summarise available data and data entry status
+
+* Data entry:
+    * Status:   {{ reference.data_entry_status }}
+    * Reviewed: {{ reference.data_review_status }}
 
 Resources
 ---------


### PR DESCRIPTION
This PR consists of three additions to the reference detail pages on RTD:

1) https://github.com/gammapy/gamma-cat/commit/43c7ab89a2090e9891457384712be7c69cc96cb4 adds the github input- and output folder to the list of basic information .

2) https://github.com/gammapy/gamma-cat/commit/f45cc6c60328f8f8d31b495638fc69a0f9539161 adds all GammaCat resources (dataset, sed, lc) stored in the output collection to the subsection 'Resources'.

3) https://github.com/gammapy/gamma-cat/commit/0815ce5385958e05c68efd0fd956a1c20b09096d adds the data entry status and the review status to the list of basic information.

The way the third change is implemented looks a little bit ugly and might need a bit clean up but for now it works and therefore it should be merged.

The diff is being very large because this PR is on top of https://github.com/gammapy/gamma-cat/pull/224. Hence, if https://github.com/gammapy/gamma-cat/pull/224 is merged the diff of this PR will be sweet and small :-)

RTM (after merge of https://github.com/gammapy/gamma-cat/pull/224)