### PR TITLE
Clean up build of input index file

### DIFF
--- a/gammacat/checks.py
+++ b/gammacat/checks.py
@@ -17,20 +17,6 @@ __all__ = [
 
 log = logging.getLogger(__name__)
 
-
-# TODO: put this in a better place?
-def check_info_yaml():
-    """Check the info.yaml files in input/data"""
-    from gammacat.utils import load_yaml, validate_schema
-
-    schema = load_yaml('input/schemas/dataset_info.schema.yaml')
-
-    for path in Path('input/data').glob('*/*/info.yaml'):
-        print(f'Checking: {path}')
-        data = load_yaml(path)
-        validate_schema(path=path, data=data, schema=schema)
-
-
 class CheckerConfig:
     """Config for Checker"""
 
@@ -86,9 +72,6 @@ class Checker:
     def check_input(self):
         log.info('Run checks: input')
         self.input_data.validate()
-        check_info_yaml()
-        print()
-        print(self.input_data)
 
     def check_collection(self):
         log.info('Run checks: collection')

--- a/gammacat/collection.py
+++ b/gammacat/collection.py
@@ -215,9 +215,7 @@ class InputCollection:
 
     def _make_index_file_for_input(self):
         resources = []
-        print(self.info_files)
-        print(type(self.info_files))
-        for info_filename in self.data.info_yaml_list:
+        for info_filename in self.info_files.to_list():
             info_data = load_yaml(info_filename)
             if info_data['data_entry']['status'] == 'missing':
                 continue

--- a/gammacat/collection.py
+++ b/gammacat/collection.py
@@ -12,7 +12,7 @@ from .sed import SED
 from .lightcurve import LightCurve
 from .dataset import DataSet
 from .info import gammacat_info, GammaCatStr
-from .input import InputData
+from .input import InputData, InputInfoCollection
 from .utils import write_json, load_json, log_list_difference, load_yaml
 
 __all__ = [
@@ -199,6 +199,47 @@ class CollectionData:
         expected_files = expected_files_extra + expected_files_sed
         log_list_difference(actual, expected_files)
 
+class InputCollection:
+
+    def __init__ (self, config):
+        self.config = config
+        self.data = InputData.read()
+        self.info_files = InputInfoCollection.read()
+
+    def run(self):
+        self._validate_info_files()
+        self._make_index_file_for_input()
+
+    def _validate_info_files(self):
+       self.info_files.validate()
+
+    def _make_index_file_for_input(self):
+        resources = []
+        print(self.info_files)
+        print(type(self.info_files))
+        for info_filename in self.data.info_yaml_list:
+            info_data = load_yaml(info_filename)
+            if info_data['data_entry']['status'] == 'missing':
+                continue
+            # TODO: Decide which datasets are copied to output collection by the keywords in 
+            # 'status' and 'reviewed' in info.yaml
+            # e.g if info_data['data_entry']['status'] == 'complete':
+            for dataset in info_data['datasets']:
+                resource = GammaCatResource(0, 'empty')
+                if dataset.endswith('yaml'):
+                    resource = DataSet.read(info_filename.parent / dataset).resource
+                elif dataset.endswith('ecsv'):
+                    if 'lc' in dataset:
+                        resource = LightCurve.read(info_filename.parent / dataset).resource
+                    elif 'sed' in dataset:
+                        resource = SED.read(info_filename.parent / dataset).resource
+                resource.location = str(info_filename.parent.relative_to(self.config.in_path) / dataset)
+                resources.append(resource)
+
+        self.index = GammaCatResourceIndex(resources).sort()
+
+        path = self.config.index_input_json
+        write_json(self.index.to_list(), path)
 
 class CollectionMaker:
     """Make gamma-cat data collection (from the input files)."""
@@ -212,8 +253,6 @@ class CollectionMaker:
         step = self.config.step
         if step == 'all':
             self.process_all()
-        elif step == 'input-index':
-            self.make_index_file_for_input()
         elif step == 'source-info':
             self.process_src_info()
         elif step == 'dataset':
@@ -233,7 +272,6 @@ class CollectionMaker:
         return InputData.read()
 
     def process_all(self):
-        self.make_index_file_for_input()
 
         self.process_src_info()
         self.process_datasets()
@@ -289,32 +327,6 @@ class CollectionMaker:
                     path = self.config.make_dataset_path(dataset, relative_to_index=False)
                     path.parent.mkdir(parents=True, exist_ok=True)
                     dataset.write(path)
-
-    def make_index_file_for_input(self):
-        resources = []
-        for info_filename in self.input_data.info_yaml_list:
-            info_data = load_yaml(info_filename)
-            if info_data['data_entry']['status'] == 'missing':
-                continue
-            # TODO: Decide which datasets are copied to output collection by the keywords in 
-            # 'status' and 'reviewed' in info.yaml
-            # e.g if info_data['data_entry']['status'] == 'complete':
-            for dataset in info_data['datasets']:
-                resource = GammaCatResource(0, 'empty')
-                if dataset.endswith('yaml'):
-                    resource = DataSet.read(info_filename.parent / dataset).resource
-                elif dataset.endswith('ecsv'):
-                    if 'lc' in dataset:
-                        resource = LightCurve.read(info_filename.parent / dataset).resource
-                    elif 'sed' in dataset:
-                        resource = SED.read(info_filename.parent / dataset).resource
-                resource.location = str(info_filename.parent.relative_to(self.config.in_path) / dataset)
-                resources.append(resource)
-
-        ri = GammaCatResourceIndex(resources).sort()
-
-        path = self.config.index_input_json
-        write_json(ri.to_list(), path)
 
     def make_index_file_for_output(self):
 

--- a/gammacat/input.py
+++ b/gammacat/input.py
@@ -254,6 +254,12 @@ class InputInfoCollection:
 
         return cls(data=data)
 
+    def to_list(self):
+        data = []
+        for infodata in self.data:
+            data.append(infodata.path)
+        return data
+
     def validate(self):
         log.info('Validating info.yaml files in `input/data`')
         [_.validate() for _ in self.data]

--- a/make.py
+++ b/make.py
@@ -8,7 +8,7 @@ import warnings
 import subprocess
 import click
 from gammacat.info import gammacat_info
-from gammacat.collection import CollectionConfig, CollectionMaker
+from gammacat.collection import CollectionConfig, CollectionMaker, InputCollection
 from gammacat.catalog import CatalogConfig, CatalogMaker
 from gammacat.webpage import WebpageConfig, WebpageMaker
 from gammacat.checks import CheckerConfig, Checker
@@ -45,7 +45,10 @@ def cli_collection(step):
         out_path=gammacat_info.out_path,
         step=step,
     )
-    CollectionMaker(config).run()
+    if (step == 'input-index'):
+        InputCollection(config).run()
+    else:
+        CollectionMaker(config).run()
 
 
 @cli.command(name='catalog')


### PR DESCRIPTION
This PR is on top of https://github.com/gammapy/gamma-cat/pull/211. Hence, you should firstly review and merge https://github.com/gammapy/gamma-cat/pull/211 before looking at the diff of this PR!

The plan is to have to classes `InputCollection` and `OutputCollection` each handling - as the names suggests - every data in the input and output folders, respectively.

This PR starts to write the `InputCollection` and it implements to first things:
1) A list of all `info.yaml` files (stored in input folder) is created via the class `InputInfoCollection` (see inline comment).
2) All of these info-files are validated (see inline comment). 
3) Secondly, the `input_index_file` is created after (!) the info-files are validated (see inline comment).
Step 2) and 3) are handled via a `run` function in `InputCollection` (see inline comment).

In the future these three steps should be the very first thing `make.py` does! This PR does not (!) change the procedure of `make.py`, it only introduces a ugly way to run the upper steps when `make.py collection --step input-index` is executed (see inline comment). There needs to be done a follow up PR which cleans up `make.py`.

The second small commit is only a small fix in the `_make_index_file_input` function so that it uses the `to_list()` function of `InputInfoCollection`. But the functionality is not changed.
