### PR TITLE
Issue 219 no2

### DIFF
--- a/gammacat/catalog.py
+++ b/gammacat/catalog.py
@@ -51,7 +51,10 @@ class DatasetConfigSource:
 
         For now, we always use the last one listed.
         """
-        return self.reference_ids[-1]
+        if (len(self.reference_ids) == 0):
+            return None
+        else:
+            return self.reference_ids[-1]
 
 
 class DatasetConfig:
@@ -542,7 +545,6 @@ class CatalogConfig:
         self.out_path = out_path
         self.source_ids = source_ids
 
-
 class CatalogMaker:
     """Make gamma-cat source catalog (from the data collection)."""
 
@@ -572,7 +574,7 @@ class CatalogMaker:
     def read_source_data(self, source_ids):
         """Gather data into Python data structures."""
         input_data = InputData.read()
-
+        
         # TODO: find a better way to load this
         resource_index = GammaCatResourceIndex.from_list(
             load_json(self.config.out_path / 'gammacat-datasets.json')
@@ -582,11 +584,7 @@ class CatalogMaker:
         for source_id in source_ids:
             basic_source_info = input_data.sources.get_source_by_id(source_id)
             log.info('Processing : {}'.format(basic_source_info))
-            try:
-                config = input_data.gammacat_dataset_config.get_source_by_id(source_id)
-                reference_id = config.get_reference_id()
-            except IndexError:
-                reference_id = None
+            reference_id = DatasetConfig.read().get_source_by_id(source_id).get_reference_id()
 
             # TODO: right now this implies, that a GammaCatSource object can only
             # handle the information from one dataset, maybe this should be changed

--- a/input/gammacat/gamma_cat_sed.yaml
+++ b/input/gammacat/gamma_cat_sed.yaml
@@ -1,0 +1,509 @@
+# This file defines which information to use when generating gamma-cat.
+#
+# At the moment it's just a simple one paper per source mapping.
+#
+
+- source_id: 1
+  status: source
+  reference_id: 2013ApJ...764...38A
+  catalog:
+    reference_id: 2013ApJ...764...38A
+    file_id: -1
+- source_id: 2
+  status: source
+  reference_id: 2013A&A...554A..72H, 2013A&A...554A..72H
+- source_id: 3
+  status: source
+  reference_id: 2011ApJ...730L..20A, 2017ApJ...836...23A
+- source_id: 4
+  status: source
+  reference_id:
+- source_id: 5
+  status: source
+  reference_id:
+- source_id: 6
+  status: source
+  reference_id:
+- source_id: 7
+  status: source
+  reference_id:
+- source_id: 8
+  status: source
+  reference_id: 2008A&A...481L.103A
+- source_id: 9
+  status: source
+  reference_id: 2014A&A...567L...8A
+- source_id: 10
+  status: source
+  reference_id:
+- source_id: 11
+  status: source
+  reference_id: 2011ApJ...726...58A
+- source_id: 12
+  status: source
+  reference_id:
+- source_id: 13
+  status: source
+  reference_id: 2014ApJ...782...13A, 2007A&A...475L...9A
+- source_id: 14
+  status: source
+  reference_id: 2008ApJ...679.1427A, 2009ApJ...700.1034A, 2011ApJ...738....3A, 2013ApJ...779...88A, 2016ApJ...817L...7A
+  catalog:
+    reference_id: 2016ApJ...817L...7A
+    file_id: 1
+- source_id: 15
+  status: source
+  reference_id: 2013A&A...559A.136H
+- source_id: 16
+  status: source
+  reference_id: 2014A&A...563A..91A
+- source_id: 17
+  status: source
+  reference_id: 2012ApJ...750...94A
+- source_id: 18
+  status: source
+  reference_id:
+- source_id: 19
+  status: source
+  reference_id: 2007A&A...473L..25A
+- source_id: 20
+  status: source
+  reference_id: 2012A&A...538A.103H, 2012ApJ...755..118A
+- source_id: 21
+  status: source
+  reference_id: 2013A&A...552A.118H
+- source_id: 22
+  status: source
+  reference_id:
+- source_id: 23
+  status: source
+  reference_id: 2013ApJ...776...69A
+- source_id: 24
+  status: source
+  reference_id: 2015Sci...347..406H
+- source_id: 25
+  status: source
+  reference_id: 2008ICRC....2..803K, 2014ApJ...781L..11A, 2006A&A...457..899A
+- source_id: 26
+  status: source
+  reference_id: 2015Sci...347..406H
+- source_id: 27
+  status: source
+  reference_id: 2012A&A...545L...2H, 2015Sci...347..406H
+- source_id: 28
+  status: source
+  reference_id:
+- source_id: 29
+  status: source
+  reference_id: 2015arXiv151201911H, 2009ApJ...698L.133A
+- source_id: 30
+  status: source
+  reference_id: 2007A&A...469L...1A, 2009ApJ...698L..94A, 2012ApJ...754L..10A, 2014ApJ...780..168A, 2016arXiv161003751S, 2017arXiv170804045M
+- source_id: 31
+  status: source
+  reference_id:
+- source_id: 32
+  status: source
+  reference_id: 2011ApJ...742..127A
+- source_id: 33
+  status: source
+  reference_id:
+- source_id: 34
+  status: source
+  reference_id: 2010ApJ...715L..49A
+- source_id: 35
+  status: source
+  reference_id: 2009ApJ...704L.129A
+- source_id: 36
+  status: source
+  reference_id: 2009ApJ...690L.126A
+- source_id: 37
+  status: source
+  reference_id: 2006A&A...448L..43A, 2012A&A...548A..38A
+- source_id: 38
+  status: source
+  reference_id:
+- source_id: 39
+  status: source
+  reference_id: 2005A&A...437L...7A, 2007ApJ...661..236A, 2016arXiv161101863H
+- source_id: 40
+  status: source
+  reference_id:
+- source_id: 41
+  status: source
+  reference_id:
+- source_id: 42
+  status: source
+  reference_id: 2012A&A...542A..94H
+- source_id: 43
+  status: source
+  reference_id: 2007ApJ...667L..21A
+- source_id: 44
+  status: source
+  reference_id: 2012A&A...541A...5H
+- source_id: 45
+  status: source
+  reference_id: 2015A&A...577A.131H
+- source_id: 46
+  status: source
+  reference_id: 2011A&A...525A..46H
+- source_id: 47
+  status: source
+  reference_id: 2011A&A...525A..46H
+- source_id: 48
+  status: source
+  reference_id: 2007A&A...470..475A
+- source_id: 49
+  status: source
+  reference_id: 1996ApJ...460..644S, 1996ApJ...472L...9B, 1999A&A...350..757A, 1999ApJ...526L..81M, 2000PhDT.........6P, 2002A&A...393...89A, 2005A&A...437...95A, 2006ApJ...641..740R, 2009ApJ...691L..13D, 2017ApJ...834....2A, 2000AIPC..515..113P, 2015NIMPA.770...42S, 2010A&A...519A..32A, 2011ApJ...738...25A, 2003ApJ...598..242A, 2010JPhG...37l5201C, 2011ApJ...734..110B, 2012JPhG...39d5201C, 2007ApJ...663..125A
+- source_id: 50
+  status: source
+  reference_id:
+- source_id: 51
+  status: source
+  reference_id:
+- source_id: 52
+  status: source
+  reference_id: 2006ApJ...648L.105A
+- source_id: 53
+  status: source
+  reference_id: 2012A&A...544A.142A, 2013ApJ...779...92A
+- source_id: 54
+  status: source
+  reference_id: 2008ApJ...684L..73A, 2008ApJ...684L..73A, 2009ApJ...707..612A
+- source_id: 55
+  status: source
+  reference_id: 2009ApJ...695.1370A, 2010ApJ...709L.163A, 2006ApJ...642L.119A
+- source_id: 56
+  status: source
+  reference_id: 2011ApJ...730L...8A
+- source_id: 57
+  status: source
+  reference_id:
+- source_id: 58
+  status: source
+  reference_id: 2012ApJ...746..151A
+- source_id: 59
+  status: source
+  reference_id: 2008Sci...320.1752M
+- source_id: 60
+  status: source
+  reference_id: 2009A&A...507..389A, 2013A&A...551A..94H, 2005A&A...442....1A
+- source_id: 61
+  status: source
+  reference_id: 2005A&A...439.1013A, 2012A&A...548A..46H
+- source_id: 62
+  status: source
+  reference_id: 2013MNRAS.434.1889H
+- source_id: 63
+  status: source
+  reference_id:
+- source_id: 64
+  status: source
+  reference_id: 2008AIPC.1085..285R, 2011A&A...533A.103H
+- source_id: 65
+  status: source
+  reference_id: 2006A&A...456..245A
+- source_id: 66
+  status: source
+  reference_id: 2006A&A...456..245A
+- source_id: 67
+  status: source
+  reference_id: 2014ApJ...785L..16A, 2014A&A...567A.135A
+- source_id: 68
+  status: source
+  reference_id: 2008A&A...477..353A
+- source_id: 69
+  status: source
+  reference_id: 2003A&A...403..523A
+- source_id: 70
+  status: source
+  reference_id: 2016arXiv160104461H
+- source_id: 71
+  status: source
+  reference_id: 2016MNRAS.461..202A
+- source_id: 72
+  status: source
+  reference_id:
+- source_id: 73
+  status: source
+  reference_id: 2012arXiv1205.0719D
+- source_id: 74
+  status: source
+  reference_id: 2010A&A...516A..62A
+- source_id: 75
+  status: source
+  reference_id: 2008AIPC.1085..281R
+- source_id: 77
+  status: source
+  reference_id: 2011A&A...525A..45H
+- source_id: 78
+  status: source
+  reference_id: 2013A&A...554A.107H
+- source_id: 79
+  status: source
+  reference_id: 2005A&A...435L..17A
+- source_id: 80
+  status: source
+  reference_id: 2015A&A...573A..31H
+- source_id: 81
+  status: source
+  reference_id: 2011ICRC....7..185A
+- source_id: 82
+  status: source
+  reference_id: 2015ApJ...802...65A, 2015ApJ...799....7A, 2012ApJ...748...46A,2008A&A...477..481A
+- source_id: 83
+  status: source
+  reference_id: 2006ApJ...636..777A, 2018arXiv180106020H
+- source_id: 84
+  status: source
+  reference_id: 2006ApJ...636..777A
+- source_id: 85
+  status: source
+  reference_id: 2008A&A...477..353A
+- source_id: 86
+  status: source
+  reference_id: 2006ApJ...636..777A
+- source_id: 87
+  status: source
+  reference_id: 2006ApJ...636..777A
+- source_id: 88
+  status: source
+  reference_id: 2006ApJ...636..777A, 2014MNRAS.439.2828A
+- source_id: 89
+  status: source
+  reference_id: 2013arXiv1303.0979O, 2014ApJ...794L...1A
+- source_id: 90
+  status: source
+  reference_id: 2012A&A...537A.114A
+- source_id: 91
+  status: source
+  reference_id: 1999A&A...342...69A, 2001ApJ...546..898A, 2001A&A...366...62A, 2008JPhG...35f5202G, 2009ApJ...705.1624A, 2012ApJ...758....2B
+- source_id: 92
+  status: source
+  reference_id: 2006ApJ...636..777A, 2008A&A...477..353A
+- source_id: 93
+  status: source
+  reference_id: 2006ApJ...636..777A, 2008A&A...477..353A
+- source_id: 94
+  status: source
+  reference_id: 2011A&A...528A.143H
+- source_id: 95
+  status: source
+  reference_id: 2006ApJ...636..777A, 2008A&A...486..829A
+- source_id: 96
+  status: source
+  reference_id: 2004Natur.432...75A, 2006A&A...449..223A, 2016arXiv160908671H
+- source_id: 97
+  status: source
+  reference_id: 2008A&A...490..685A
+- source_id: 98
+  status: source
+  reference_id: 2015A&A...574A.100H
+- source_id: 99
+  status: source
+  reference_id: 2007A&A...472..489A
+- source_id: 100
+  status: source
+  reference_id:
+- source_id: 101
+  status: source
+  reference_id: 2015ApJ...808..110A
+- source_id: 102
+  status: source
+  reference_id: 2011A&A...531A..81H
+- source_id: 103
+  status: source
+  reference_id: 2008A&A...477..353A, 2011A&A...531A..81H
+- source_id: 104
+  status: source
+  reference_id: 2008AIPC.1085..249T, 2017arXiv171101350H
+- source_id: 105
+  status: source
+  reference_id: 2016MNRAS.459.2550A
+- source_id: 106
+  status: source
+  reference_id: 2004A&A...425L..13A, 2006PhRvL..97v1102A, 2009A&A...503..817A, 2016Natur.531..476H
+- source_id: 107
+  status: source
+  reference_id:
+- source_id: 108
+  status: source
+  reference_id: 2006ApJ...636..777A, 2008A&A...483..509A
+- source_id: 109
+  status: source
+  reference_id: 2011A&A...531L..18H
+- source_id: 110
+  status: source
+  reference_id: 2005A&A...432L..25A
+- source_id: 111
+  status: source
+  reference_id:
+- source_id: 112
+  status: source
+  reference_id: 2008A&A...481..401A
+- source_id: 113
+  status: source
+  reference_id: 2006ApJ...636..777A
+- source_id: 114
+  status: source
+  reference_id: 2016arXiv160605404A
+- source_id: 115
+  status: source
+  reference_id: 2007A&A...472..489A
+- source_id: 116
+  status: source
+  reference_id: 2006ApJ...636..777A
+- source_id: 117
+  status: source
+  reference_id: 2014A&A...562A..40H
+- source_id: 118
+  status: source
+  reference_id: 2005A&A...442L..25A, 2006ApJ...636..777A, 2006A&A...460..365A
+- source_id: 119
+  status: source
+  reference_id: 2005Sci...309..746A, 2006A&A...460..743A
+- source_id: 120
+  status: source
+  reference_id: 2011ICRC....7..244S
+- source_id: 121
+  status: source
+  reference_id: 2015MNRAS.446.1163H
+- source_id: 122
+  status: source
+  reference_id:
+- source_id: 123
+  status: source
+  reference_id: 2006ApJ...636..777A
+- source_id: 124
+  status: source
+  reference_id: 2006ApJ...636..777A
+- source_id: 125
+  status: source
+  reference_id: 2008A&A...477..353A
+- source_id: 126
+  status: source
+  reference_id:
+- source_id: 127
+  status: source
+  reference_id:
+- source_id: 128
+  status: source
+  reference_id: 2008AIPC.1085..372C
+- source_id: 129
+  status: source
+  reference_id:
+- source_id: 130
+  status: source
+  reference_id: 2008A&A...477..353A
+- source_id: 131
+  status: source
+  reference_id: 2008A&A...477..353A
+- source_id: 132
+  status: source
+  reference_id: 2009A&A...499..723A, 2014ApJ...787..166A
+- source_id: 133
+  status: source
+  reference_id: 2016arXiv160900600H
+- source_id: 134
+  status: source
+  reference_id: 2008A&A...484..435A, 2018arXiv180106020H
+- source_id: 135
+  status: source
+  reference_id: 2012A&A...541A..13A
+- source_id: 136
+  status: source
+  reference_id: 2010ApJ...719L..69A
+- source_id: 137
+  status: source
+  reference_id: 2016arXiv161005799S, 2011A&A...529A..49H
+- source_id: 138
+  status: source
+  reference_id: 2003ApJ...583L...9H, 2003ICRC....5.2615T, 2003A&A...406L...9A, 2008ApJ...679.1029T, 2013ApJ...775....3A, 2005ApJ...621..181D, 2006ApJ...639..761A
+- source_id: 139
+  status: source
+  reference_id:
+- source_id: 140
+  status: source
+  reference_id: 2010A&A...511A..52H
+- source_id: 141
+  status: source
+  reference_id: 2014ApJ...788...78A
+- source_id: 142
+  status: source
+  reference_id:
+- source_id: 143
+  status: source
+  reference_id: 2012ApJ...753..159A, 2014ApJ...788...78A
+- source_id: 144
+  status: source
+  reference_id: 2013ApJ...770...93A
+- source_id: 145
+  status: source
+  reference_id:
+- source_id: 146
+  status: source
+  reference_id: 2012ApJ...753..159A, 2014ApJ...783...16A
+- source_id: 147
+  status: source
+  reference_id: 2013PhRvD..88j2003A, 2005A&A...430..865A, 2012A&A...544A..75A, 2009ApJ...696L.150A, 2005A&A...442..895A, 2012A&A...539A.149H,2010A&A...520A..83H
+- source_id: 148
+  status: source
+  reference_id: 2007ApJ...666L..17A, 2013ApJ...762...92A
+- source_id: 149
+  status: source
+  reference_id: 2009ApJ...703L...6A
+- source_id: 150
+  status: source
+  reference_id:
+- source_id: 151
+  status: source
+  reference_id:
+- source_id: 152
+  status: source
+  reference_id: 2012A&A...539A.118A
+- source_id: 153
+  status: source
+  reference_id: 2015arXiv151100309G, 2010ApJ...714..163A
+- source_id: 154
+  status: source
+  reference_id: 2005ApJ...634..947S, 2013A&A...556A..67A, 2007ApJ...662..892A, 2011ApJ...738..169A
+- source_id: 155
+  status: source
+  reference_id: 2010A&A...516A..56H
+- source_id: 156
+  status: source
+  reference_id: 2008A&A...481..401A
+- source_id: 157
+  status: source
+  reference_id:
+- source_id: 158
+  status: source
+  reference_id: 2018arXiv180106020H
+- source_id: 159
+  status: source
+  reference_id: 2017arXiv170604535H
+- source_id: 160
+  status: source
+  reference_id:
+- source_id: 161
+  status: source
+  reference_id: 2017arXiv170107002A
+- source_id: 162
+  status: source
+  reference_id:
+- source_id: 163
+  status: source
+  reference_id:
+- source_id: 164
+  status: source
+  reference_id:
+- source_id: 165
+  status: source
+  reference_id: 2016ApJ...821..129A
+- source_id: 166
+  status: source
+  reference_id:
+- source_id: 167
+  status: source
+  reference_id: 2015ApJ...815L..22A

--- a/input/schemas/gamma_cat_sed.schema.yaml
+++ b/input/schemas/gamma_cat_sed.schema.yaml
@@ -1,0 +1,22 @@
+type: array
+items:
+
+  type: object
+  additionalProperties: false
+
+  properties:
+    source_id: {type: integer}
+    status:
+      enum: [source, candidate, removed]
+      # Status of this source in gamma-cat
+      # source - A normal source
+      # candidate - A source candidate
+      # removed - Not a source. Has been removed. (usually when one source splits in several new sources)
+
+    reference_id: {type: [string, "null"]}
+    catalog:
+      type: object
+      properties:
+        reference_id:
+          type: [string, "null"]
+          file_id: [integer, "null"]


### PR DESCRIPTION
This is one way how to control which SED goes to the catalog.

If you look to input/gammacat/gamma_cat_sed.yaml and there at source_id = 1, you can see the idea:
- source_id and status is nothing new
- reference_id: all references where at least one sed-file of the source is stored
- catalog:
      - reference_id: The reference_id of the sed which goes to the catalog
      - file_id: If there are more than one sed file, the file with file_id goes to the catalog (if there is only one file, the default value is -1)

I only want to introduce this idea of a schema and if it is agreed then one needs to add the keywords to all sources. 